### PR TITLE
Henter correlationId fra header istedenfor å generere.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-val dusseldorfKtorVersion = "1.5.2.7462190"
+val dusseldorfKtorVersion = "1.5.2.1303b90"
 val ktorVersion = "1.5.2"
 val mainClass = "no.nav.k9.K9LosKt"
 val kafkaVersion = "2.7.0" // Alligned med version fra kafka-embedded-env

--- a/src/main/kotlin/no/nav/k9/K9Los.kt
+++ b/src/main/kotlin/no/nav/k9/K9Los.kt
@@ -206,7 +206,7 @@ fun Application.k9Los() {
     }
 
     install(CallId) {
-        generated()
+        fromXCorrelationIdHeader()
     }
 }
 


### PR DESCRIPTION
Har oppdatert proxyen som logger litt mer vettuge ting + at den setter correlationId i loggen & propagerer den videre.
Så om api'et henter denne verdien så kan man enklere matche her også.

```
Mar 26, 2021 @ 12:30:04.776 | 200 OK: POST - /api/k9-los-api/saksbehandler/oppgaver/reserver (136ms)
Mar 26, 2021 @ 12:30:01.437 | 200 OK: GET - /api/k9-los-api/saksbehandler/oppgaver/behandlede (26ms)
Mar 26, 2021 @ 12:30:01.413 | 200 OK: GET - /api/k9-los-api/saksbehandler/oppgaver/reserverte (32ms)
Mar 26, 2021 @ 12:30:01.107 | 200 OK: GET - /api/k9-los-api/konfig/omsorgspenger-url (21ms)
```