### PR TITLE
fjerner sjekk eventhendelser fordi

### DIFF
--- a/src/main/kotlin/no/nav/k9/domene/modell/K9SakModell.kt
+++ b/src/main/kotlin/no/nav/k9/domene/modell/K9SakModell.kt
@@ -4,7 +4,6 @@ import no.nav.k9.domene.lager.oppgave.Oppgave
 import no.nav.k9.domene.repository.ReservasjonRepository
 import no.nav.k9.domene.repository.SaksbehandlerRepository
 import no.nav.k9.integrasjon.kafka.dto.BehandlingProsessEventDto
-import no.nav.k9.integrasjon.kafka.dto.EventHendelse
 import no.nav.k9.integrasjon.sakogbehandling.kontrakt.BehandlingAvsluttet
 import no.nav.k9.integrasjon.sakogbehandling.kontrakt.BehandlingOpprettet
 import no.nav.k9.kodeverk.behandling.aksjonspunkt.AksjonspunktDefinisjon
@@ -50,9 +49,6 @@ data class K9SakModell(
             oppgaveAvsluttet = sisteEvent.eventTid
         }
 
-        if (sisteEvent.eventHendelse == EventHendelse.AKSJONSPUNKT_AVBRUTT || sisteEvent.eventHendelse == EventHendelse.AKSJONSPUNKT_UTFØRT) {
-            aktiv = false
-        }
         if (FagsakYtelseType.fraKode(sisteEvent.ytelseTypeKode) == FagsakYtelseType.FRISINN) {
             aktiv = false
         }

--- a/src/main/kotlin/no/nav/k9/domene/modell/K9TilbakeModell.kt
+++ b/src/main/kotlin/no/nav/k9/domene/modell/K9TilbakeModell.kt
@@ -4,7 +4,6 @@ import no.nav.k9.domene.lager.oppgave.Oppgave
 import no.nav.k9.domene.repository.ReservasjonRepository
 import no.nav.k9.domene.repository.SaksbehandlerRepository
 import no.nav.k9.integrasjon.kafka.dto.BehandlingProsessEventTilbakeDto
-import no.nav.k9.integrasjon.kafka.dto.EventHendelse
 import no.nav.k9.integrasjon.sakogbehandling.kontrakt.BehandlingAvsluttet
 import no.nav.k9.integrasjon.sakogbehandling.kontrakt.BehandlingOpprettet
 import no.nav.k9.statistikk.kontrakter.Aktør
@@ -36,9 +35,6 @@ data class K9TilbakeModell(
             oppgaveAvsluttet = sisteEvent.eventTid
         }
 
-        if (sisteEvent.eventHendelse == EventHendelse.AKSJONSPUNKT_AVBRUTT || sisteEvent.eventHendelse == EventHendelse.AKSJONSPUNKT_UTFØRT) {
-            aktiv = false
-        }
         if (FagsakYtelseType.fraKode(sisteEvent.ytelseTypeKode) == FagsakYtelseType.FRISINN) {
             aktiv = false
         }


### PR DESCRIPTION
k9-tilbake
* i k9-tilbake kan flere aksjonspunkter være aktive, men hvis kun en av dem utføres/avbrytes så skal oppgaven fortsatt være aktiv. Denne koden deaktiverer hele oppgaven. Det er derfor bedre å sjekke om behandling har noen aktive aksjonspunkter.
* hvis behandlingen avsluttes så skal oppgaven lukkes uavhengig av status på aksjonspunkter. Dette vil fanges opp av status sjekk lenger nede.

k9-sak
* k9-sak bruker EventHendelse.AKSJONSPUNKT_AVBRUTT kun når behandling er avsluttet. Dette sjekkes også lenger ned gjennom behandlingsStatus
* k9-sak sender aldri EventHendelse.AKSJONSPUNKT_UTFØRT