### PR TITLE
Feilhåndtering i KøOppdatert-jobb

### DIFF
--- a/src/main/kotlin/no/nav/k9/eventhandler/CoroutineUtil.kt
+++ b/src/main/kotlin/no/nav/k9/eventhandler/CoroutineUtil.kt
@@ -1,0 +1,16 @@
+package no.nav.k9.eventhandler
+
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.asCoroutineDispatcher
+import org.slf4j.LoggerFactory
+import java.util.concurrent.ExecutorService
+import kotlin.coroutines.CoroutineContext
+
+val EXCEPTION_HANDLER = CoroutineExceptionHandler { _, exception ->
+        val log = LoggerFactory.getLogger("CoroutineExceptionHandler")
+        log.error("Uncaught exception in coroutine", exception)
+    }
+
+fun ExecutorService.asCoroutineDispatcherWithErrorHandling(): CoroutineContext {
+    return asCoroutineDispatcher() + EXCEPTION_HANDLER
+}

--- a/src/main/kotlin/no/nav/k9/eventhandler/KøOppdatert.kt
+++ b/src/main/kotlin/no/nav/k9/eventhandler/KøOppdatert.kt
@@ -27,7 +27,7 @@ fun CoroutineScope.køOppdatertProsessor(
     oppgaveTjeneste: OppgaveTjeneste,
     reservasjonRepository: ReservasjonRepository,
     k9SakService: IK9SakService
-) = launch(Executors.newSingleThreadExecutor().asCoroutineDispatcher()) {
+) = launch(Executors.newSingleThreadExecutor().asCoroutineDispatcherWithErrorHandling()) {
     val log = LoggerFactory.getLogger("behandleOppgave")
     for (uuid in channel) {
         try {


### PR DESCRIPTION
- Hindrer at feil i coroutine stopper den, og logger feilen istedet som error
- Fjernet dobbel polling av kø