### PR TITLE
Fikser feil som gjør at oppfriskningsrutinen av oppgaver i k9sak stopper

### DIFF
--- a/src/main/kotlin/no/nav/k9/domene/repository/OppgaveRepository.kt
+++ b/src/main/kotlin/no/nav/k9/domene/repository/OppgaveRepository.kt
@@ -31,7 +31,7 @@ import javax.sql.DataSource
 class OppgaveRepository(
     private val dataSource: DataSource,
     private val pepClient: IPepClient,
-    private val refreshOppgave: Channel<Oppgave>
+    private val refreshOppgave: Channel<UUID>
 ) {
     private val log: Logger = LoggerFactory.getLogger(OppgaveRepository::class.java)
     fun hent(): List<Oppgave> {
@@ -398,7 +398,7 @@ class OppgaveRepository(
         }
         val oppgaver =
             json.map { s -> objectMapper().readValue(s, Oppgave::class.java) }.filter { it.kode6 == kode6 }.toList()
-        oppgaver.forEach { refreshOppgave.offer(it) }
+        oppgaver.forEach { refreshOppgave.trySend(it.eksternId) }
         Databasekall.map.computeIfAbsent(object {}.javaClass.name + object {}.javaClass.enclosingMethod.name) { LongAdder() }
             .increment()
         return oppgaver
@@ -419,7 +419,7 @@ class OppgaveRepository(
             )
         }
         val oppgaver = json.map { objectMapper().readValue(it, Oppgave::class.java) }.filter { it.kode6 == kode6 }
-        oppgaver.forEach { refreshOppgave.offer(it) }
+        oppgaver.forEach { refreshOppgave.trySend(it.eksternId) }
         Databasekall.map.computeIfAbsent(object {}.javaClass.name + object {}.javaClass.enclosingMethod.name) { LongAdder() }
             .increment()
 
@@ -706,7 +706,7 @@ class OppgaveRepository(
             )
         }
         val oppgaver = json.map { objectMapper().readValue(it, Oppgave::class.java) }.filter { it.kode6 == kode6 }
-        oppgaver.forEach { refreshOppgave.offer(it) }
+        oppgaver.forEach { refreshOppgave.trySend(it.eksternId) }
         Databasekall.map.computeIfAbsent(object {}.javaClass.name + object {}.javaClass.enclosingMethod.name) { LongAdder() }
             .increment()
 

--- a/src/main/kotlin/no/nav/k9/eventhandler/KøOppdatert.kt
+++ b/src/main/kotlin/no/nav/k9/eventhandler/KøOppdatert.kt
@@ -1,8 +1,6 @@
 package no.nav.k9.eventhandler
 
-import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.launch
 import no.nav.k9.domene.lager.oppgave.v2.OppgaveRepositoryV2

--- a/src/test/kotlin/no/nav/k9/tjenester/saksbehandler/oppgave/OppgaveTjenesteSettSkjermetTest.kt
+++ b/src/test/kotlin/no/nav/k9/tjenester/saksbehandler/oppgave/OppgaveTjenesteSettSkjermetTest.kt
@@ -196,8 +196,7 @@ class OppgaveTjenesteSettSkjermetTest : KoinTest, AbstractPostgresTest() {
     fun `hent fagsak`(){
         val oppgaveKøOppdatert = Channel<UUID>(1)
         val refreshKlienter = Channel<SseEvent>(1000)
-        val oppgaverRefresh = Channel<Oppgave>(1000)
-        val oppgaveRefreshOppdatert = Channel<UUID>(100)
+        val oppgaverRefresh = Channel<UUID>(1000)
 
         val oppgaveRepository = OppgaveRepository(dataSource = dataSource,pepClient = PepClientLocal(), refreshOppgave = oppgaverRefresh)
         val oppgaveRepositoryV2 = OppgaveRepositoryV2(dataSource = dataSource)
@@ -207,7 +206,7 @@ class OppgaveTjenesteSettSkjermetTest : KoinTest, AbstractPostgresTest() {
             oppgaveKøOppdatert = oppgaveKøOppdatert,
             oppgaveRepositoryV2 = oppgaveRepositoryV2,
             refreshKlienter = refreshKlienter,
-            oppgaveRefreshChannel = oppgaveRefreshOppdatert,
+            oppgaveRefreshChannel = oppgaverRefresh,
             pepClient = PepClientLocal()
         )
         val pdlService = mockk<PdlService>()
@@ -295,9 +294,8 @@ class OppgaveTjenesteSettSkjermetTest : KoinTest, AbstractPostgresTest() {
     fun hentReservasjonsHistorikk() = runBlocking {
         val oppgaveKøOppdatert = Channel<UUID>(1)
         val refreshKlienter = Channel<SseEvent>(1000)
-        val oppgaveRefreshOppdatert = Channel<UUID>(100)
 
-        val oppgaverRefresh = Channel<Oppgave>(1000)
+        val oppgaverRefresh = Channel<UUID>(1000)
 
         val oppgaveRepository = OppgaveRepository(dataSource = dataSource,pepClient = PepClientLocal(), refreshOppgave = oppgaverRefresh)
         val oppgaveRepositoryV2 = OppgaveRepositoryV2(dataSource = dataSource)
@@ -307,7 +305,7 @@ class OppgaveTjenesteSettSkjermetTest : KoinTest, AbstractPostgresTest() {
             oppgaveRepositoryV2 = oppgaveRepositoryV2,
             oppgaveKøOppdatert = oppgaveKøOppdatert,
             refreshKlienter = refreshKlienter,
-            oppgaveRefreshChannel = oppgaveRefreshOppdatert,
+            oppgaveRefreshChannel = oppgaverRefresh,
             pepClient = PepClientLocal()
         )
         val saksbehandlerRepository = SaksbehandlerRepository(dataSource = dataSource,


### PR DESCRIPTION
Endret eventkildene til å kun sende UUID istedenfor en miks av UUID og Oppgave på samme kanal. 
Lagt på logging ved exception i refreshK9 coroutine.