### PR TITLE
Legger til metode i Oppgave for å sjekke om fagsaksnummer er en tom streng

### DIFF
--- a/src/main/kotlin/no/nav/k9/domene/lager/oppgave/Oppgave.kt
+++ b/src/main/kotlin/no/nav/k9/domene/lager/oppgave/Oppgave.kt
@@ -58,6 +58,11 @@ data class Oppgave(
     data class FagsakPeriode(
         val fom: LocalDate, val tom: LocalDate
     )
+
+    //TODO Dette burde endres. FagsaksNummer er ikke nullable, men kan pr dags dato være en tom streng
+    fun harFagSaksNummer(): Boolean {
+        return fagsakSaksnummer.isNotBlank()
+    }
 }
 
 data class OppgaveMedId(

--- a/src/main/kotlin/no/nav/k9/domene/lager/oppgave/Oppgave.kt
+++ b/src/main/kotlin/no/nav/k9/domene/lager/oppgave/Oppgave.kt
@@ -59,7 +59,7 @@ data class Oppgave(
         val fom: LocalDate, val tom: LocalDate
     )
 
-    //TODO Dette burde endres. FagsaksNummer er ikke nullable, men kan pr dags dato være en tom streng
+    //TODO Dette burde endres. FagsaksNummer er ikke nullable, men kan pr dags dato være en tom streng. Burde derfor endres til String?
     fun harFagSaksNummer(): Boolean {
         return fagsakSaksnummer.isNotBlank()
     }

--- a/src/main/kotlin/no/nav/k9/integrasjon/abac/IPepClient.kt
+++ b/src/main/kotlin/no/nav/k9/integrasjon/abac/IPepClient.kt
@@ -1,5 +1,7 @@
 package no.nav.k9.integrasjon.abac
 
+import no.nav.k9.domene.lager.oppgave.Oppgave
+
 interface IPepClient {
 
     suspend fun erOppgaveStyrer(): Boolean
@@ -31,4 +33,6 @@ interface IPepClient {
 
     suspend fun erAktørKode6(aktørid: String): Boolean
     suspend fun erAktørKode7EllerEgenAnsatt(aktørid: String): Boolean
+
+    suspend fun harTilgangTilOppgave(oppgave: Oppgave) : Boolean
 }

--- a/src/main/kotlin/no/nav/k9/integrasjon/abac/PepClient.kt
+++ b/src/main/kotlin/no/nav/k9/integrasjon/abac/PepClient.kt
@@ -12,6 +12,7 @@ import no.nav.helse.dusseldorf.ktor.core.Retry
 import no.nav.helse.dusseldorf.ktor.metrics.Operation
 import no.nav.k9.Configuration
 import no.nav.k9.aksjonspunktbehandling.objectMapper
+import no.nav.k9.domene.lager.oppgave.Oppgave
 import no.nav.k9.integrasjon.audit.*
 import no.nav.k9.integrasjon.azuregraph.IAzureGraphService
 import no.nav.k9.integrasjon.rest.NavHeaders
@@ -204,6 +205,13 @@ class PepClient constructor(
             .addResourceAttribute(RESOURCE_AKTØR_ID, aktørid)
 
         return !evaluate(requestBuilder)
+    }
+
+    override suspend fun harTilgangTilOppgave(oppgave: Oppgave): Boolean {
+        return !oppgave.harFagSaksNummer() || harTilgangTilLesSak(
+            fagsakNummer = oppgave.fagsakSaksnummer,
+            aktørid = oppgave.aktorId
+        )
     }
 
     private suspend fun evaluate(xacmlRequestBuilder: XacmlRequestBuilder): Boolean {

--- a/src/main/kotlin/no/nav/k9/integrasjon/abac/PepClientLocal.kt
+++ b/src/main/kotlin/no/nav/k9/integrasjon/abac/PepClientLocal.kt
@@ -1,5 +1,7 @@
 package no.nav.k9.integrasjon.abac
 
+import no.nav.k9.domene.lager.oppgave.Oppgave
+
 class PepClientLocal : IPepClient {
     override suspend fun erOppgaveStyrer(): Boolean {
         return true
@@ -43,6 +45,10 @@ class PepClientLocal : IPepClient {
 
     override suspend fun erAktørKode7EllerEgenAnsatt(aktørid: String): Boolean {
         return false
+    }
+
+    override suspend fun harTilgangTilOppgave(oppgave: Oppgave): Boolean {
+        return true
     }
 
 }

--- a/src/main/kotlin/no/nav/k9/tjenester/avdelingsleder/AvdelingslederTjeneste.kt
+++ b/src/main/kotlin/no/nav/k9/tjenester/avdelingsleder/AvdelingslederTjeneste.kt
@@ -2,7 +2,6 @@ package no.nav.k9.tjenester.avdelingsleder
 
 import no.nav.k9.Configuration
 import no.nav.k9.KoinProfile
-import no.nav.k9.domene.lager.oppgave.Oppgave
 import no.nav.k9.domene.lager.oppgave.Reservasjon
 import no.nav.k9.domene.modell.Enhet
 import no.nav.k9.domene.modell.FagsakYtelseType
@@ -307,7 +306,7 @@ class AvdelingslederTjeneste(
                 val oppgave = oppgaveRepository.hent(uuid)
 
                 if (configuration.koinProfile() != KoinProfile.LOCAL &&
-                    !harTilgangTilOppgave(oppgave)
+                    !pepClient.harTilgangTilOppgave(oppgave)
                 ) {
                     continue
                 }
@@ -333,12 +332,6 @@ class AvdelingslederTjeneste(
         return list.sortedWith(compareBy({ it.reservertAvNavn }, { it.reservertTilTidspunkt }))
     }
 
-    private suspend fun harTilgangTilOppgave(oppgave: Oppgave) : Boolean {
-        return !oppgave.harFagSaksNummer() || pepClient.harTilgangTilLesSak(
-            fagsakNummer = oppgave.fagsakSaksnummer,
-            aktørid = oppgave.aktorId
-        )
-    }
 
     suspend fun opphevReservasjon(uuid: UUID): Reservasjon {
         val reservasjon = reservasjonRepository.lagre(uuid, true) {

--- a/src/main/kotlin/no/nav/k9/tjenester/avdelingsleder/AvdelingslederTjeneste.kt
+++ b/src/main/kotlin/no/nav/k9/tjenester/avdelingsleder/AvdelingslederTjeneste.kt
@@ -2,6 +2,7 @@ package no.nav.k9.tjenester.avdelingsleder
 
 import no.nav.k9.Configuration
 import no.nav.k9.KoinProfile
+import no.nav.k9.domene.lager.oppgave.Oppgave
 import no.nav.k9.domene.lager.oppgave.Reservasjon
 import no.nav.k9.domene.modell.Enhet
 import no.nav.k9.domene.modell.FagsakYtelseType
@@ -306,10 +307,7 @@ class AvdelingslederTjeneste(
                 val oppgave = oppgaveRepository.hent(uuid)
 
                 if (configuration.koinProfile() != KoinProfile.LOCAL &&
-                    !oppgave.harFagSaksNummer() || !pepClient.harTilgangTilLesSak(
-                        fagsakNummer = oppgave.fagsakSaksnummer,
-                        aktørid = oppgave.aktorId
-                    )
+                    !harFagsaksNummerOgHarTilgangTilLesSak(oppgave)
                 ) {
                     continue
                 }
@@ -333,6 +331,13 @@ class AvdelingslederTjeneste(
         }
 
         return list.sortedWith(compareBy({ it.reservertAvNavn }, { it.reservertTilTidspunkt }))
+    }
+
+    private suspend fun harFagsaksNummerOgHarTilgangTilLesSak(oppgave: Oppgave) : Boolean {
+        return oppgave.harFagSaksNummer() && pepClient.harTilgangTilLesSak(
+            fagsakNummer = oppgave.fagsakSaksnummer,
+            aktørid = oppgave.aktorId
+        )
     }
 
     suspend fun opphevReservasjon(uuid: UUID): Reservasjon {

--- a/src/main/kotlin/no/nav/k9/tjenester/avdelingsleder/AvdelingslederTjeneste.kt
+++ b/src/main/kotlin/no/nav/k9/tjenester/avdelingsleder/AvdelingslederTjeneste.kt
@@ -305,7 +305,8 @@ class AvdelingslederTjeneste(
 
                 val oppgave = oppgaveRepository.hent(uuid)
 
-                if (configuration.koinProfile() != KoinProfile.LOCAL && !pepClient.harTilgangTilLesSak(
+                if (configuration.koinProfile() != KoinProfile.LOCAL &&
+                    !oppgave.harFagSaksNummer() || !pepClient.harTilgangTilLesSak(
                         fagsakNummer = oppgave.fagsakSaksnummer,
                         aktørid = oppgave.aktorId
                     )

--- a/src/main/kotlin/no/nav/k9/tjenester/avdelingsleder/AvdelingslederTjeneste.kt
+++ b/src/main/kotlin/no/nav/k9/tjenester/avdelingsleder/AvdelingslederTjeneste.kt
@@ -307,7 +307,7 @@ class AvdelingslederTjeneste(
                 val oppgave = oppgaveRepository.hent(uuid)
 
                 if (configuration.koinProfile() != KoinProfile.LOCAL &&
-                    !harFagsaksNummerOgHarTilgangTilLesSak(oppgave)
+                    !harTilgangTilOppgave(oppgave)
                 ) {
                     continue
                 }
@@ -333,8 +333,8 @@ class AvdelingslederTjeneste(
         return list.sortedWith(compareBy({ it.reservertAvNavn }, { it.reservertTilTidspunkt }))
     }
 
-    private suspend fun harFagsaksNummerOgHarTilgangTilLesSak(oppgave: Oppgave) : Boolean {
-        return oppgave.harFagSaksNummer() && pepClient.harTilgangTilLesSak(
+    private suspend fun harTilgangTilOppgave(oppgave: Oppgave) : Boolean {
+        return !oppgave.harFagSaksNummer() || pepClient.harTilgangTilLesSak(
             fagsakNummer = oppgave.fagsakSaksnummer,
             aktørid = oppgave.aktorId
         )

--- a/src/main/kotlin/no/nav/k9/tjenester/saksbehandler/oppgave/OppgaveTjeneste.kt
+++ b/src/main/kotlin/no/nav/k9/tjenester/saksbehandler/oppgave/OppgaveTjeneste.kt
@@ -451,7 +451,7 @@ class OppgaveTjeneste constructor(
     private suspend fun lagOppgaveDtoer(oppgaver: List<Oppgave>): OppgaverResultat {
         var ikkeTilgang = false
         val oppgaver = oppgaver.filter { oppgave ->
-            if (!pepClient.harTilgangTilLesSak(
+            if (!oppgave.harFagSaksNummer() || !pepClient.harTilgangTilLesSak(
                     fagsakNummer = oppgave.fagsakSaksnummer,
                     aktørid = oppgave.aktorId
                 )
@@ -788,7 +788,7 @@ class OppgaveTjeneste constructor(
                     if (list.size == 10) {
                         break
                     }
-                    if (!pepClient.harTilgangTilLesSak(
+                    if (!oppgave.harFagSaksNummer() || !pepClient.harTilgangTilLesSak(
                             fagsakNummer = oppgave.fagsakSaksnummer,
                             aktørid = oppgave.aktorId
                         )
@@ -942,7 +942,7 @@ class OppgaveTjeneste constructor(
     }
 
     private suspend fun tilgangTilSak(oppgave: Oppgave): Boolean {
-        if (!pepClient.harTilgangTilLesSak(
+        if (!oppgave.harFagSaksNummer() || !pepClient.harTilgangTilLesSak(
                 fagsakNummer = oppgave.fagsakSaksnummer,
                 aktørid = oppgave.aktorId
             )
@@ -1082,7 +1082,7 @@ class OppgaveTjeneste constructor(
             val person = pdlService.person(oppgave.aktorId)
 
             oppgaveDto = lagOppgaveDto(oppgavePar.second!!, person.person?.navn() ?: "Ukjent", person.person)
-            if (!pepClient.harTilgangTilLesSak(
+            if (!oppgave.harFagSaksNummer() || !pepClient.harTilgangTilLesSak(
                     fagsakNummer = oppgavePar.second!!.fagsakSaksnummer,
                     aktørid = oppgavePar.second!!.aktorId
                 )

--- a/src/main/kotlin/no/nav/k9/tjenester/saksbehandler/oppgave/OppgaveTjeneste.kt
+++ b/src/main/kotlin/no/nav/k9/tjenester/saksbehandler/oppgave/OppgaveTjeneste.kt
@@ -451,7 +451,7 @@ class OppgaveTjeneste constructor(
     private suspend fun lagOppgaveDtoer(oppgaver: List<Oppgave>): OppgaverResultat {
         var ikkeTilgang = false
         val oppgaver = oppgaver.filter { oppgave ->
-            if (!harTilgangTilOppgave(oppgave)) {
+            if (!pepClient.harTilgangTilOppgave(oppgave)) {
                 settSkjermet(oppgave)
                 ikkeTilgang = true
                 false
@@ -784,7 +784,7 @@ class OppgaveTjeneste constructor(
                     if (list.size == 10) {
                         break
                     }
-                    if (!harTilgangTilOppgave(oppgave)) {
+                    if (!pepClient.harTilgangTilOppgave(oppgave)) {
                         settSkjermet(oppgave)
                         continue
                     }
@@ -934,7 +934,7 @@ class OppgaveTjeneste constructor(
     }
 
     private suspend fun tilgangTilSak(oppgave: Oppgave): Boolean {
-        if (!harTilgangTilOppgave(oppgave)) {
+        if (!pepClient.harTilgangTilOppgave(oppgave)) {
             reservasjonRepository.lagre(oppgave.eksternId, true) {
                 it!!.reservertTil = null
                 runBlocking { saksbehandlerRepository.fjernReservasjon(it.reservertAv, it.oppgave) }
@@ -1070,7 +1070,7 @@ class OppgaveTjeneste constructor(
             val person = pdlService.person(oppgave.aktorId)
 
             oppgaveDto = lagOppgaveDto(oppgavePar.second!!, person.person?.navn() ?: "Ukjent", person.person)
-            if (!harTilgangTilOppgave(oppgave)) {
+            if (!pepClient.harTilgangTilOppgave(oppgave)) {
                 // skal ikke få oppgave saksbehandler ikke har lestilgang til
                 settSkjermet(oppgavePar.second!!)
                 oppgaverSomErBlokert.add(oppgaveDto)
@@ -1205,12 +1205,6 @@ class OppgaveTjeneste constructor(
         return Pair(oppgaverSomIKkeErBlokkert.first(), null)
     }
 
-    private suspend fun harTilgangTilOppgave(oppgave: Oppgave) : Boolean {
-        return !oppgave.harFagSaksNummer() || pepClient.harTilgangTilLesSak(
-            fagsakNummer = oppgave.fagsakSaksnummer,
-            aktørid = oppgave.aktorId
-        )
-    }
 }
 
 private fun BehandlingStatus.underBehandling() = this != BehandlingStatus.AVSLUTTET && this != BehandlingStatus.LUKKET

--- a/src/main/kotlin/no/nav/k9/tjenester/saksbehandler/oppgave/OppgaveTjeneste.kt
+++ b/src/main/kotlin/no/nav/k9/tjenester/saksbehandler/oppgave/OppgaveTjeneste.kt
@@ -1214,5 +1214,3 @@ class OppgaveTjeneste constructor(
 }
 
 private fun BehandlingStatus.underBehandling() = this != BehandlingStatus.AVSLUTTET && this != BehandlingStatus.LUKKET
-
-

--- a/src/main/kotlin/no/nav/k9/tjenester/saksbehandler/oppgave/OppgaveTjeneste.kt
+++ b/src/main/kotlin/no/nav/k9/tjenester/saksbehandler/oppgave/OppgaveTjeneste.kt
@@ -451,7 +451,7 @@ class OppgaveTjeneste constructor(
     private suspend fun lagOppgaveDtoer(oppgaver: List<Oppgave>): OppgaverResultat {
         var ikkeTilgang = false
         val oppgaver = oppgaver.filter { oppgave ->
-            if (!harFagsaksNummerOgHarTilgangTilLesSak(oppgave)) {
+            if (!harTilgangTilOppgave(oppgave)) {
                 settSkjermet(oppgave)
                 ikkeTilgang = true
                 false
@@ -784,7 +784,7 @@ class OppgaveTjeneste constructor(
                     if (list.size == 10) {
                         break
                     }
-                    if (!harFagsaksNummerOgHarTilgangTilLesSak(oppgave)) {
+                    if (!harTilgangTilOppgave(oppgave)) {
                         settSkjermet(oppgave)
                         continue
                     }
@@ -934,7 +934,7 @@ class OppgaveTjeneste constructor(
     }
 
     private suspend fun tilgangTilSak(oppgave: Oppgave): Boolean {
-        if (!harFagsaksNummerOgHarTilgangTilLesSak(oppgave)) {
+        if (!harTilgangTilOppgave(oppgave)) {
             reservasjonRepository.lagre(oppgave.eksternId, true) {
                 it!!.reservertTil = null
                 runBlocking { saksbehandlerRepository.fjernReservasjon(it.reservertAv, it.oppgave) }
@@ -1070,7 +1070,7 @@ class OppgaveTjeneste constructor(
             val person = pdlService.person(oppgave.aktorId)
 
             oppgaveDto = lagOppgaveDto(oppgavePar.second!!, person.person?.navn() ?: "Ukjent", person.person)
-            if (!harFagsaksNummerOgHarTilgangTilLesSak(oppgave)) {
+            if (!harTilgangTilOppgave(oppgave)) {
                 // skal ikke få oppgave saksbehandler ikke har lestilgang til
                 settSkjermet(oppgavePar.second!!)
                 oppgaverSomErBlokert.add(oppgaveDto)
@@ -1205,8 +1205,8 @@ class OppgaveTjeneste constructor(
         return Pair(oppgaverSomIKkeErBlokkert.first(), null)
     }
 
-    private suspend fun harFagsaksNummerOgHarTilgangTilLesSak(oppgave: Oppgave) : Boolean {
-        return oppgave.harFagSaksNummer() && pepClient.harTilgangTilLesSak(
+    private suspend fun harTilgangTilOppgave(oppgave: Oppgave) : Boolean {
+        return !oppgave.harFagSaksNummer() || pepClient.harTilgangTilLesSak(
             fagsakNummer = oppgave.fagsakSaksnummer,
             aktørid = oppgave.aktorId
         )

--- a/src/test/kotlin/no/nav/k9/tjenester/saksbehandler/oppgave/OppgaveTjenesteSettSkjermetTest.kt
+++ b/src/test/kotlin/no/nav/k9/tjenester/saksbehandler/oppgave/OppgaveTjenesteSettSkjermetTest.kt
@@ -178,7 +178,7 @@ class OppgaveTjenesteSettSkjermetTest : KoinTest, AbstractPostgresTest() {
             )
         ))
         coEvery { pepClient.harBasisTilgang() } returns true
-        coEvery { pepClient.harTilgangTilLesSak(any(),any()) } returns true
+        coEvery { pepClient.harTilgangTilOppgave(any()) } returns true
 
         var oppgaver = oppgaveTjeneste.hentNesteOppgaverIKø(oppgaveko.id)
         assert(oppgaver.size == 1)
@@ -267,7 +267,7 @@ class OppgaveTjenesteSettSkjermetTest : KoinTest, AbstractPostgresTest() {
 
         coEvery {  azureGraphService.hentIdentTilInnloggetBruker() } returns "123"
         every { config.koinProfile() } returns KoinProfile.LOCAL
-        coEvery { pepClient.harTilgangTilLesSak(any(), any()) } returns true
+        coEvery { pepClient.harTilgangTilOppgave(any()) } returns true
         coEvery { omsorgspengerService.hentOmsorgspengerSakDto(any()) } returns null
         coEvery { pdlService.person(any()) } returns PersonPdlResponse(false, PersonPdl(data = PersonPdl.Data(
             hentPerson = PersonPdl.Data.HentPerson(
@@ -392,7 +392,7 @@ class OppgaveTjenesteSettSkjermetTest : KoinTest, AbstractPostgresTest() {
         }
         every { config.koinProfile() } returns KoinProfile.LOCAL
         coEvery { pepClient.harBasisTilgang() } returns true
-        coEvery { pepClient.harTilgangTilLesSak(any(),any()) } returns true
+        coEvery { pepClient.harTilgangTilOppgave(any()) } returns true
         coEvery { pepClient.harTilgangTilReservingAvOppgaver() } returns true
         coEvery { pdlService.person(any()) } returns PersonPdlResponse(false, PersonPdl(
             data = PersonPdl.Data(


### PR DESCRIPTION
Denne er ikke nullable, men kan være en tom streng. Bruker den nye metoden for å sjekke om vi har fagsaksnummer før vi gjør tilgangskontroll via PepClient#harTilgangTilLesSak(), siden det ikke gir mening å sjekke tilgang hvis vi ikke har fagsaksnummer. Et eksempel på når dette kan skje er for punsjoppgaver, hvor vi ikke har fagsaksnummer