### PR TITLE
Endrer endepunktet til å ta i mot Array i stedet for List

### DIFF
--- a/src/main/kotlin/no/nav/k9/tjenester/avdelingsleder/AvdelingslederTjeneste.kt
+++ b/src/main/kotlin/no/nav/k9/tjenester/avdelingsleder/AvdelingslederTjeneste.kt
@@ -285,7 +285,7 @@ class AvdelingslederTjeneste(
         }
     }
 
-    suspend fun leggFjernSaksbehandlereFraOppgaveKø(saksbehandlereDto: List<SaksbehandlerOppgavekoDto>) {
+    suspend fun leggFjernSaksbehandlereFraOppgaveKø(saksbehandlereDto: Array<SaksbehandlerOppgavekoDto>) {
         val saksbehandlerKøId = saksbehandlereDto.first().id
         if (!saksbehandlereDto.all { it.id == saksbehandlerKøId }) {
             throw IllegalArgumentException("Støtter ikke å legge til eller fjerne saksbehandlere fra flere køer samtidig")

--- a/src/main/kotlin/no/nav/k9/tjenester/avdelingsleder/oppgaveko/AvdelingslederOppgavekoApis.kt
+++ b/src/main/kotlin/no/nav/k9/tjenester/avdelingsleder/oppgaveko/AvdelingslederOppgavekoApis.kt
@@ -99,7 +99,7 @@ fun Route.AvdelingslederOppgavekøApis() {
 
     post("/saksbehandlere") {
         requestContextService.withRequestContext(call) {
-            val saksbehandlere = call.receive<List<SaksbehandlerOppgavekoDto>>()
+            val saksbehandlere = call.receive<Array<SaksbehandlerOppgavekoDto>>()
             call.respond(avdelingslederTjeneste.leggFjernSaksbehandlereFraOppgaveKø(saksbehandlere))
         }
     }

--- a/src/test/kotlin/no/nav/k9/tjenester/avdelingsleder/AvdelingslederTjenesteTest.kt
+++ b/src/test/kotlin/no/nav/k9/tjenester/avdelingsleder/AvdelingslederTjenesteTest.kt
@@ -39,7 +39,7 @@ internal class AvdelingslederTjenesteTest : AbstractK9LosIntegrationTest() {
             val id = avdelingslederTjeneste.opprettOppgaveKø()
             val saksbehandlerDto = saksbehandlere.map {
                 SaksbehandlerOppgavekoDto(id.id, it.epost, true)
-            }
+            }.toTypedArray()
 
             avdelingslederTjeneste.leggFjernSaksbehandlereFraOppgaveKø(saksbehandlerDto)
             val oppgaveKø = avdelingslederTjeneste.hentOppgaveKø(UUID.fromString(id.id))
@@ -56,7 +56,7 @@ internal class AvdelingslederTjenesteTest : AbstractK9LosIntegrationTest() {
             val id = avdelingslederTjeneste.opprettOppgaveKø()
             val saksbehandlerDto = saksbehandlere.map {
                 SaksbehandlerOppgavekoDto(id.id, it.epost, true)
-            }
+            }.toTypedArray()
 
             avdelingslederTjeneste.leggFjernSaksbehandlereFraOppgaveKø(saksbehandlerDto)
             var oppgaveKø = avdelingslederTjeneste.hentOppgaveKø(UUID.fromString(id.id))
@@ -77,7 +77,7 @@ internal class AvdelingslederTjenesteTest : AbstractK9LosIntegrationTest() {
             val id = avdelingslederTjeneste.opprettOppgaveKø()
             var saksbehandlerDto = saksbehandlere.map {
                 SaksbehandlerOppgavekoDto(id.id, it.epost, true)
-            }
+            }.toTypedArray()
 
             avdelingslederTjeneste.leggFjernSaksbehandlereFraOppgaveKø(saksbehandlerDto)
             var oppgaveKø = avdelingslederTjeneste.hentOppgaveKø(UUID.fromString(id.id))
@@ -85,7 +85,7 @@ internal class AvdelingslederTjenesteTest : AbstractK9LosIntegrationTest() {
 
             saksbehandlerDto = saksbehandlere.map {
                 SaksbehandlerOppgavekoDto(id.id, it.epost, false)
-            }
+            }.toTypedArray()
 
             avdelingslederTjeneste.leggFjernSaksbehandlereFraOppgaveKø(saksbehandlerDto)
             oppgaveKø = avdelingslederTjeneste.hentOppgaveKø(UUID.fromString(id.id))
@@ -102,13 +102,13 @@ internal class AvdelingslederTjenesteTest : AbstractK9LosIntegrationTest() {
             val id = avdelingslederTjeneste.opprettOppgaveKø()
             var saksbehandlerDto = saksbehandlere.map {
                 SaksbehandlerOppgavekoDto(id.id, it.epost, true)
-            }
+            }.toTypedArray()
 
             avdelingslederTjeneste.leggFjernSaksbehandlereFraOppgaveKø(saksbehandlerDto)
             var oppgaveKø = avdelingslederTjeneste.hentOppgaveKø(UUID.fromString(id.id))
             assertThat(oppgaveKø.saksbehandlere.size == saksbehandlerDto.size)
 
-            saksbehandlerDto = listOf(
+            saksbehandlerDto = arrayOf(
                 SaksbehandlerOppgavekoDto(id.id, saksbehandlere[0].epost, true),
                 SaksbehandlerOppgavekoDto(id.id, saksbehandlere[1].epost, false),
             )


### PR DESCRIPTION
Endrer endepunktet til å ta i mot Array i stedet for List, siden deserialiseringen i call.receive gjør om payload til en ```ArrayList<LinkedHashMap>``` om man ikke bruker Array