### PR TITLE
Håndtering av ny consumer id for eksisterende topic/stream i aiven

### DIFF
--- a/nais/kafka/produksjonsstyring-k9sak.yml
+++ b/nais/kafka/produksjonsstyring-k9sak.yml
@@ -14,7 +14,7 @@ spec:
     partitions: 3
     replication: 3  # see min/max requirements
     retentionBytes: -1  # -1 means unlimited
-    retentionHours: 2160 # 90 dager
+    retentionHours: 720 # 30 dager
   acl:
     - team: k9saksbehandling
       application: k9-sak

--- a/src/main/kotlin/no/nav/k9/los/domene/lager/oppgave/v2/OppgaveTjenesteV2.kt
+++ b/src/main/kotlin/no/nav/k9/los/domene/lager/oppgave/v2/OppgaveTjenesteV2.kt
@@ -24,8 +24,10 @@ open class OppgaveTjenesteV2(
                 ?: migreringstjeneste.hentBehandlingFraTidligereProsessEvents(eksternId)
                 ?: throw IllegalStateException("Mottatt hendelse uten å ha behandling. $eksternId")
 
-            hendelser.forEach { behandling.nyHendelse(it) }
-            oppgaveRepository.lagre(behandling, tx)
+            if (!behandling.erFerdigstilt()) {
+                hendelser.forEach { behandling.nyHendelse(it) }
+                oppgaveRepository.lagre(behandling, tx)
+            }
         }
     }
 

--- a/src/main/kotlin/no/nav/k9/los/fagsystem/k9sak/K9SakStream.kt
+++ b/src/main/kotlin/no/nav/k9/los/fagsystem/k9sak/K9SakStream.kt
@@ -24,7 +24,7 @@ internal class K9SakStream constructor(
 
     private val stream = ManagedKafkaStreams(
         name = NAME,
-        properties = kafkaConfig.stream(NAME, OffsetResetStrategy.NONE),
+        properties = kafkaConfig.stream(NAME, OffsetResetStrategy.EARLIEST),
         topology = topology(
             configuration = configuration,
             k9sakEventHandler = k9sakEventHandlerv2


### PR DESCRIPTION
Setter samme retention time som det nye punsj -aksjonspunkt-topic i aiven (30 dager).

Ignorerer hendelser på ferdigstilte behandlinger, og bruker reset strategy earliest for å få offset på ny consumer group.