### PR TITLE
Ruller tilbake kafkaversjon til 3.2.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ val jacksonVersion = "2.13.4"
 
 val dusseldorfKtorVersion = "3.2.2.2-d9c7672"
 val ktorVersion = "2.2.2"
-val kafkaVersion = "3.3.1"
+val kafkaVersion = "3.2.3"
 
 val navTilgangskontroll = "2.2022.11.16_08.36-35c94368bc44"
 


### PR DESCRIPTION
Oppstart av k9-los kaster for tiden en stacktrace.

org.apache.kafka.streams.internals.metrics.ClientMetrics ] - Error while loading kafka-streams-version.properties
java.lang.NullPointerException: inStream parameter is null
	at java.base/java.util.Objects.requireNonNull(Objects.java:233)
	at java.base/java.util.Properties.load(Properties.java:407)
	at org.apache.kafka.streams.internals.metrics.ClientMetrics.<clinit>(ClientMetrics.java:53)
	....
	
Mistanken er at dette påvirker monitorering og automatisk restart ved kafkaproblemer, men det er strengt tatt ikke bekreftet. Kafka-streams jar-filen mangler kafka-streams-version.properties i alle 3.3.x versjoner. Dette er fikset igjen til 3.4.0 som er like rundt hjørnet. Tenkte vi kunne rulle tilbake til gammel versjon i mellomtiden.