### PR TITLE
Utvider query til å også kunne bruke LocalDate i tillegg til LocalDateTime

### DIFF
--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/query/db/SqlOppgaveQuery.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/query/db/SqlOppgaveQuery.kt
@@ -3,6 +3,7 @@ package no.nav.k9.los.nyoppgavestyring.query.db
 import org.postgresql.util.PGInterval
 import java.math.BigDecimal
 import java.math.BigInteger
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 class SqlOppgaveQuery {
@@ -82,6 +83,9 @@ class SqlOppgaveQuery {
          */
         val timestampFeltverdi = try {
             LocalDateTime.parse(feltverdi as String)
+        } catch (e: Exception) { null } ?:
+        try {
+            LocalDate.parse(feltverdi as String)
         } catch (e: Exception) { null }
 
         val durationFeltverdi = try {

--- a/src/main/resources/adapterdefinisjoner/k9-feltdefinisjoner-v2.json
+++ b/src/main/resources/adapterdefinisjoner/k9-feltdefinisjoner-v2.json
@@ -78,13 +78,13 @@
     {
       "id": "mottattDato",
       "listetype": false,
-      "tolkesSom": "String",
+      "tolkesSom": "Timestamp",
       "visTilBruker": true
     },
     {
       "id": "registrertDato",
       "listetype": false,
-      "tolkesSom": "String",
+      "tolkesSom": "Timestamp",
       "visTilBruker": true
     },
     {

--- a/src/test/kotlin/no/nav/k9/los/TestDataSource.kt
+++ b/src/test/kotlin/no/nav/k9/los/TestDataSource.kt
@@ -36,7 +36,7 @@ class KPostgreSQLContainer(imageName: String) : PostgreSQLContainer<KPostgreSQLC
 
 abstract class AbstractPostgresTest {
     companion object {
-        private val postgresContainer = KPostgreSQLContainer("postgres:11.1")
+        private val postgresContainer = KPostgreSQLContainer("postgres:12")
             .withDatabaseName("my-db")
             .withUsername("foo")
             .withPassword("secret")
@@ -66,6 +66,7 @@ abstract class AbstractPostgresTest {
                 ferdigstilte_behandlinger,
                 nye_og_ferdigstilte,
                 oppgave,
+                oppgavefelt_verdi,
                 oppgaveko,
                 reservasjon,
                 saksbehandler,

--- a/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/OppgaveTestDataBuilder.kt
+++ b/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/OppgaveTestDataBuilder.kt
@@ -1,0 +1,85 @@
+package no.nav.k9.los.nyoppgavestyring
+
+import no.nav.k9.los.domene.lager.oppgave.v2.TransactionalManager
+import no.nav.k9.los.nyoppgavestyring.domeneadaptere.k9.saktillos.K9SakTilLosAdapterTjeneste
+import no.nav.k9.los.nyoppgavestyring.mottak.omraade.Område
+import no.nav.k9.los.nyoppgavestyring.mottak.oppgave.OppgaveFeltverdi
+import no.nav.k9.los.nyoppgavestyring.mottak.oppgave.OppgaveV3
+import no.nav.k9.los.nyoppgavestyring.mottak.oppgave.OppgaveV3Repository
+import no.nav.k9.los.nyoppgavestyring.mottak.oppgave.Oppgavestatus
+import no.nav.k9.los.nyoppgavestyring.mottak.oppgavetype.*
+import org.koin.test.KoinTest
+import org.koin.test.get
+import java.time.LocalDateTime
+import java.util.*
+
+class OppgaveTestDataBuilder(
+    val område: Område = Område(1, "K9"),
+    val definisjonskilde: String = "k9-sak-til-los",
+    val oppgaveTypeNavn: String = "k9sak"
+): KoinTest {
+    val transactionManager = get<TransactionalManager>()
+    val oppgavetypeRepo = get<OppgavetypeRepository>()
+    val oppgaverepo = get<OppgaveV3Repository>()
+    val k9SakTilLosAdapterTjeneste = get<K9SakTilLosAdapterTjeneste>()
+
+    init {
+        k9SakTilLosAdapterTjeneste.setup()
+    }
+
+    val oppgaveFeltverdier = mutableSetOf<OppgaveFeltverdi>()
+
+
+    val oppgavetype = transactionManager.transaction { tx ->
+        val oppgavetype = oppgavetypeRepo.hent(område, definisjonskilde, tx)
+        oppgavetype.oppgavetyper
+            .firstOrNull { it.eksternId == oppgaveTypeNavn }
+            ?: throw IllegalStateException("Fant ikke oppgavetype for $oppgaveTypeNavn i db")
+    }
+
+    fun medOppgaveFeltVerdi(feltTypeKode: FeltType, verdi: String): OppgaveTestDataBuilder {
+        val oppgavefelter = oppgavetype.oppgavefelter
+            .firstOrNull { it.feltDefinisjon.eksternId == feltTypeKode.eksternId }
+            ?: throw IllegalStateException("Fant ikke ønsket feltdefinisjon i db")
+
+        oppgaveFeltverdier.add(
+            OppgaveFeltverdi(null, oppgavefelter, verdi)
+        )
+        return this
+    }
+
+
+    fun lagOgLagre(): OppgaveV3 {
+        val antall = oppgaverepo.tellAntall().first
+        return transactionManager.transaction { tx ->
+            val oppgave = OppgaveV3(
+                id = antall,
+                eksternId = UUID.randomUUID().toString(),
+                eksternVersjon = "0",
+                oppgavetype = oppgavetype,
+                status = Oppgavestatus.AAPEN,
+                endretTidspunkt = LocalDateTime.now(),
+                kildeområde = område.eksternId,
+                felter = oppgaveFeltverdier.toList(),
+                reservasjonsnøkkel = ""
+            )
+            oppgaverepo.nyOppgaveversjon(oppgave, tx)
+            oppgave
+        }
+    }
+}
+
+enum class FeltType(
+    val eksternId: String,
+    val listetype: Boolean = false,
+    val tolkesSom: String = "String"
+) {
+    behandlingUuid("behandlingUuid"),
+    fagsystem("fagsystem"),
+    aksjonspunkt("aksjonspunkt", true),
+    resultattype("resultattype", true),
+    totrinnskontroll("totrinnskontroll", tolkesSom = "Boolean"),
+    behandlingsstatus("behandlingsstatus", true),
+    ytelsestype("ytelsestype", true),
+    mottattDato("mottattDato")
+}

--- a/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/query/OppgaveQueryTest.kt
+++ b/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/query/OppgaveQueryTest.kt
@@ -3,14 +3,17 @@ package no.nav.k9.los.nyoppgavestyring.query
 import assertk.assertThat
 import assertk.assertions.isEmpty
 import assertk.assertions.isNotNull
+import assertk.assertions.isNotEmpty
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.mockk.mockk
 import no.nav.helse.dusseldorf.ktor.jackson.dusseldorfConfigured
 import no.nav.k9.los.AbstractK9LosIntegrationTest
-import no.nav.k9.los.domene.repository.StatistikkRepository
+import no.nav.k9.los.nyoppgavestyring.FeltType
+import no.nav.k9.los.nyoppgavestyring.OppgaveTestDataBuilder
 import no.nav.k9.los.nyoppgavestyring.mottak.feltdefinisjon.FeltdefinisjonRepository
+import no.nav.k9.los.nyoppgavestyring.query.db.FeltverdiOperator
 import no.nav.k9.los.nyoppgavestyring.query.db.OppgaveQueryRepository
 import no.nav.k9.los.nyoppgavestyring.query.dto.query.CombineOppgavefilter
 import no.nav.k9.los.nyoppgavestyring.query.dto.query.FeltverdiOppgavefilter
@@ -51,6 +54,105 @@ class OppgaveQueryTest : AbstractK9LosIntegrationTest() {
 
         val result = oppgaveQueryRepository.query(oppgaveQuery)
         assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `sjekker at oppgave-query kan utvides ved flere verdier i filter`() {
+        OppgaveTestDataBuilder()
+            .medOppgaveFeltVerdi(FeltType.aksjonspunkt, "5016")
+            .lagOgLagre()
+
+        val oppgaveQueryRepository = OppgaveQueryRepository(dataSource, mockk<FeltdefinisjonRepository>())
+        val oppgaveQuery = OppgaveQuery(listOf(
+            byggFilterK9(FeltType.aksjonspunkt, FeltverdiOperator.EQUALS, "5016")
+        ))
+
+        val om = ObjectMapper().dusseldorfConfigured()
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .registerKotlinModule()
+        val sw = StringWriter()
+        om.writeValue(sw, oppgaveQuery)
+
+        val result = oppgaveQueryRepository.query(oppgaveQuery)
+        assertThat(result).isNotEmpty()
+    }
+
+    @Test
+    fun `sjekker at oppgave-query kan sammenligne timestamp`() {
+        OppgaveTestDataBuilder()
+            .medOppgaveFeltVerdi(FeltType.mottattDato, "2023-05-15T00:00:00.000")
+            .lagOgLagre()
+
+        val oppgaveQueryRepository = OppgaveQueryRepository(dataSource, mockk<FeltdefinisjonRepository>())
+
+        assertThat(oppgaveQueryRepository.query(OppgaveQuery(listOf(
+            byggFilterK9(FeltType.mottattDato, FeltverdiOperator.GREATER_THAN, "2023-05-14T00:00:00.000"),
+        )))).isNotEmpty()
+
+        assertThat(oppgaveQueryRepository.query(OppgaveQuery(listOf(
+            byggFilterK9(FeltType.mottattDato, FeltverdiOperator.LESS_THAN, "2023-05-15T00:00:00.000"),
+        )))).isEmpty()
+
+        assertThat(oppgaveQueryRepository.query(OppgaveQuery(listOf(
+            byggFilterK9(FeltType.mottattDato, FeltverdiOperator.GREATER_THAN, "2023-05-15T00:00:00.000"),
+        )))).isEmpty()
+
+        assertThat(oppgaveQueryRepository.query(OppgaveQuery(listOf(
+            byggFilterK9(FeltType.mottattDato, FeltverdiOperator.LESS_THAN, "2023-05-16T00:00:00.000"),
+        )))).isNotEmpty()
+    }
+
+    @Test
+    fun `sjekker at oppgave-query kan sjekke timestamp for likhet - urealistisk med timestamp`() {
+        OppgaveTestDataBuilder()
+            .medOppgaveFeltVerdi(FeltType.mottattDato, "2023-05-15T00:00:00.000")
+            .lagOgLagre()
+
+        val oppgaveQueryRepository = OppgaveQueryRepository(dataSource, mockk<FeltdefinisjonRepository>())
+
+        assertThat(oppgaveQueryRepository.query(OppgaveQuery(listOf(
+            byggFilterK9(FeltType.mottattDato, FeltverdiOperator.LESS_THAN_OR_EQUALS, "2023-05-15T00:00:00.000"),
+        )))).isNotEmpty()
+
+        assertThat(oppgaveQueryRepository.query(OppgaveQuery(listOf(
+            byggFilterK9(FeltType.mottattDato, FeltverdiOperator.EQUALS, "2023-05-15T00:00:00.000"),
+        )))).isNotEmpty()
+
+        assertThat(oppgaveQueryRepository.query(OppgaveQuery(listOf(
+            byggFilterK9(FeltType.mottattDato, FeltverdiOperator.GREATER_THAN_OR_EQUALS, "2023-05-15T00:00:00.000"),
+        )))).isNotEmpty()
+    }
+
+
+    @Test
+    fun `sjekker at oppgave-query med kun dato kan sjekkes mot timestamp`() {
+        OppgaveTestDataBuilder()
+            .medOppgaveFeltVerdi(FeltType.mottattDato, "2023-05-15T00:00:00.000")
+            .lagOgLagre()
+
+        val oppgaveQueryRepository = OppgaveQueryRepository(dataSource, mockk<FeltdefinisjonRepository>())
+
+        assertThat(oppgaveQueryRepository.query(OppgaveQuery(listOf(
+            byggFilterK9(FeltType.mottattDato, FeltverdiOperator.LESS_THAN_OR_EQUALS, "2023-05-16"),
+        )))).isNotEmpty()
+
+        assertThat(oppgaveQueryRepository.query(OppgaveQuery(listOf(
+            byggFilterK9(FeltType.mottattDato, FeltverdiOperator.EQUALS, "2023-05-15"),
+        )))).isNotEmpty()
+
+        assertThat(oppgaveQueryRepository.query(OppgaveQuery(listOf(
+            byggFilterK9(FeltType.mottattDato, FeltverdiOperator.GREATER_THAN_OR_EQUALS, "2023-05-14"),
+        )))).isNotEmpty()
+    }
+
+
+    private fun byggFilterK9(feltType: FeltType, feltverdiOperator: FeltverdiOperator, vararg verdier: String): FeltverdiOppgavefilter {
+        return FeltverdiOppgavefilter(
+            "K9",
+            feltType.eksternId,
+            feltverdiOperator.name,
+            verdier.toList()
+        )
     }
 
     @Test


### PR DESCRIPTION
Askepterer både LocalDate og LocalDateTime i query.
Endret tidsfelter til å være Timestamp istedenfor String.
Tester på oppgavequery som inkluderer db. Sletter OppgaveVerdier mellom hver test.