### PR TITLE
Mapper behandlingssteg fra sak- og klageeventene

### DIFF
--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/klagetillos/EventTilDtoMapper.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/klagetillos/EventTilDtoMapper.kt
@@ -204,6 +204,10 @@ class EventTilDtoMapper {
                 verdi = event.behandlingStatus ?: BehandlingStatus.UTREDES.kode
             ),
             OppgaveFeltverdiDto(
+                nøkkel = "behandlingssteg",
+                verdi = event.behandlingSteg
+            ),
+            OppgaveFeltverdiDto(
                 nøkkel = "behandlingTypekode",
                 verdi = event.behandlingTypeKode
             ),

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/saktillos/EventTilDtoMapper.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/saktillos/EventTilDtoMapper.kt
@@ -146,6 +146,10 @@ class EventTilDtoMapper {
                 verdi = event.behandlingStatus ?: BehandlingStatus.UTREDES.kode
             ),
             OppgaveFeltverdiDto(
+                nøkkel = "behandlingssteg",
+                verdi = event.behandlingSteg
+            ),
+            OppgaveFeltverdiDto(
                 nøkkel = "behandlingTypekode",
                 verdi = event.behandlingTypeKode
             ),


### PR DESCRIPTION
Feltet er tomt i oppgavefiltre som følge av manglende mapping