### PR TITLE
Feltdefinisjonene har nå et visningsnavn.

### DIFF
--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/mottak/feltdefinisjon/Feltdefinisjon.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/mottak/feltdefinisjon/Feltdefinisjon.kt
@@ -7,9 +7,11 @@ class Feltdefinisjon(
     val id: Long? = null,
     val eksternId: String,
     val område: Område,
+    val visningsnavn: String,
     val listetype: Boolean,
     val tolkesSom: String,
     val visTilBruker: Boolean,
+    val kokriterie: Boolean,
     val kodeverkreferanse: Kodeverkreferanse?,
 ) {
     override fun equals(other: Any?): Boolean {
@@ -20,9 +22,11 @@ class Feltdefinisjon(
 
         if (eksternId != other.eksternId) return false
         if (område != other.område) return false
+        if (visningsnavn != other.visningsnavn) return false
         if (listetype != other.listetype) return false
         if (tolkesSom != other.tolkesSom) return false
         if (visTilBruker != other.visTilBruker) return false
+        if (kokriterie != other.kokriterie) return false
         if (kodeverkreferanse != other.kodeverkreferanse) return false
 
         return true
@@ -31,9 +35,11 @@ class Feltdefinisjon(
     override fun hashCode(): Int {
         var result = eksternId.hashCode()
         result = 31 * result + område.hashCode()
+        result = 31 * result + visningsnavn.hashCode()
         result = 31 * result + listetype.hashCode()
         result = 31 * result + tolkesSom.hashCode()
         result = 31 * result + visTilBruker.hashCode()
+        result = 31 * result + kokriterie.hashCode()
         result = 31 * result + kodeverkreferanse.hashCode()
         return result
     }

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/mottak/feltdefinisjon/FeltdefinisjonDto.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/mottak/feltdefinisjon/FeltdefinisjonDto.kt
@@ -2,8 +2,10 @@ package no.nav.k9.los.nyoppgavestyring.mottak.feltdefinisjon
 
 data class FeltdefinisjonDto(
     val id: String,
+    val visningsnavn: String,
     val listetype: Boolean,
     val tolkesSom: String,
     val visTilBruker: Boolean,
+    val kokriterie: Boolean,
     val kodeverkreferanse: KodeverkReferanseDto?,
 )

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/mottak/feltdefinisjon/FeltdefinisjonRepository.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/mottak/feltdefinisjon/FeltdefinisjonRepository.kt
@@ -28,9 +28,11 @@ class FeltdefinisjonRepository(val områdeRepository: OmrådeRepository) {
                     id = row.long("id"),
                     eksternId = row.string("ekstern_id"),
                     område = område,
+                    visningsnavn = row.string("visningsnavn"),
                     listetype = row.boolean("liste_type"),
                     tolkesSom = row.string("tolkes_som"),
                     visTilBruker = row.boolean("vis_til_bruker"),
+                    kokriterie = row.boolean("kokriterie"),
                     kodeverkreferanse = row.stringOrNull("kodeverkreferanse")?.let { Kodeverkreferanse(it) }
                 )
             }.asList
@@ -66,14 +68,16 @@ class FeltdefinisjonRepository(val områdeRepository: OmrådeRepository) {
                 queryOf(
                     """
                     update feltdefinisjon 
-                    set liste_type = :listeType, tolkes_som = :tolkesSom, vis_til_bruker = :visTilBruker, kodeverkreferanse = :kodeverkreferanse
+                    set visningsnavn = :visningsnavn, liste_type = :listeType, tolkes_som = :tolkesSom, vis_til_bruker = :visTilBruker, kokriterie = :kokriterie, kodeverkreferanse = :kodeverkreferanse
                     WHERE omrade_id = :omradeId AND ekstern_id = :eksternId""",
                     mapOf(
                         "eksternId" to datatype.eksternId,
                         "omradeId" to område.id,
+                        "visningsnavn" to datatype.visningsnavn,
                         "listeType" to datatype.listetype,
                         "tolkesSom" to datatype.tolkesSom,
                         "visTilBruker" to datatype.visTilBruker,
+                        "kokriterie" to datatype.kokriterie,
                         "kodeverkreferanse" to datatype.kodeverkreferanse?.let { it.toDatabasestreng() }
                     )
                 ).asUpdate
@@ -86,14 +90,16 @@ class FeltdefinisjonRepository(val områdeRepository: OmrådeRepository) {
             tx.run(
                 queryOf(
                     """
-                    insert into feltdefinisjon(ekstern_id, omrade_id, liste_type, tolkes_som, vis_til_bruker, kodeverkreferanse) 
-                    values(:eksternId, :omradeId, :listeType, :tolkesSom, :visTilBruker, :kodeverkreferanse)""",
+                    insert into feltdefinisjon(ekstern_id, omrade_id, visningsnavn, liste_type, tolkes_som, vis_til_bruker, kokriterie, kodeverkreferanse) 
+                    values(:eksternId, :omradeId, :visningsnavn, :listeType, :tolkesSom, :visTilBruker, :kokriterie, :kodeverkreferanse)""",
                     mapOf(
                         "eksternId" to feltdefinisjon.eksternId,
                         "omradeId" to område.id,
+                        "visningsnavn" to feltdefinisjon.visningsnavn,
                         "listeType" to feltdefinisjon.listetype,
                         "tolkesSom" to feltdefinisjon.tolkesSom,
                         "visTilBruker" to feltdefinisjon.visTilBruker,
+                        "kokriterie" to feltdefinisjon.kokriterie,
                         "kodeverkreferanse" to feltdefinisjon.kodeverkreferanse?.let { it.toDatabasestreng() }
                     )
                 ).asUpdate

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/mottak/feltdefinisjon/FeltdefinisjonRepository.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/mottak/feltdefinisjon/FeltdefinisjonRepository.kt
@@ -68,7 +68,12 @@ class FeltdefinisjonRepository(val områdeRepository: OmrådeRepository) {
                 queryOf(
                     """
                     update feltdefinisjon 
-                    set visningsnavn = :visningsnavn, liste_type = :listeType, tolkes_som = :tolkesSom, vis_til_bruker = :visTilBruker, kokriterie = :kokriterie, kodeverkreferanse = :kodeverkreferanse
+                    set visningsnavn = :visningsnavn,
+                      liste_type = :listeType,
+                      tolkes_som = :tolkesSom,
+                      vis_til_bruker = :visTilBruker,
+                      kokriterie = :kokriterie,
+                      kodeverkreferanse = :kodeverkreferanse
                     WHERE omrade_id = :omradeId AND ekstern_id = :eksternId""",
                     mapOf(
                         "eksternId" to datatype.eksternId,
@@ -90,8 +95,26 @@ class FeltdefinisjonRepository(val områdeRepository: OmrådeRepository) {
             tx.run(
                 queryOf(
                     """
-                    insert into feltdefinisjon(ekstern_id, omrade_id, visningsnavn, liste_type, tolkes_som, vis_til_bruker, kokriterie, kodeverkreferanse) 
-                    values(:eksternId, :omradeId, :visningsnavn, :listeType, :tolkesSom, :visTilBruker, :kokriterie, :kodeverkreferanse)""",
+                    insert into feltdefinisjon (
+                      ekstern_id,
+                      omrade_id,
+                      visningsnavn,
+                      liste_type,
+                      tolkes_som,
+                      vis_til_bruker,
+                      kokriterie,
+                      kodeverkreferanse
+                    ) 
+                    values (
+                      :eksternId,
+                      :omradeId,
+                      :visningsnavn,
+                      :listeType,
+                      :tolkesSom,
+                      :visTilBruker,
+                      :kokriterie,
+                      :kodeverkreferanse
+                    )""",
                     mapOf(
                         "eksternId" to feltdefinisjon.eksternId,
                         "omradeId" to område.id,
@@ -132,8 +155,8 @@ class FeltdefinisjonRepository(val områdeRepository: OmrådeRepository) {
         val kodeverkId = tx.updateAndReturnGeneratedKey(
             queryOf(
                 """
-                    insert into kodeverk(omrade_id, ekstern_id, beskrivelse, uttommende)
-                    values(:omradeId, :eksternId, :beskrivelse, :uttommende)
+                    insert into kodeverk (omrade_id, ekstern_id, beskrivelse, uttommende)
+                    values (:omradeId, :eksternId, :beskrivelse, :uttommende)
                     on conflict (omrade_id, ekstern_id) do update set beskrivelse = :beskrivelse, uttommende = :uttommende 
                 """.trimIndent(),
                 mapOf(

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/mottak/feltdefinisjon/Feltdefinisjoner.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/mottak/feltdefinisjon/Feltdefinisjoner.kt
@@ -13,9 +13,11 @@ class Feltdefinisjoner(
             Feltdefinisjon(
                 eksternId = feltdefinisjonDto.id,
                 område = område,
+                visningsnavn = feltdefinisjonDto.visningsnavn,
                 listetype = feltdefinisjonDto.listetype,
                 tolkesSom = feltdefinisjonDto.tolkesSom,
                 visTilBruker = feltdefinisjonDto.visTilBruker,
+                kokriterie = feltdefinisjonDto.kokriterie,
                 kodeverkreferanse = feltdefinisjonDto.kodeverkreferanse?.let { kodeverkreferanseDto -> Kodeverkreferanse(kodeverkreferanseDto) }
             )
         }.toSet()

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/query/dto/felter/Oppgavefelt.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/query/dto/felter/Oppgavefelt.kt
@@ -5,6 +5,7 @@ class Oppgavefelt(
     val kode: String,
     val visningsnavn: String,
     val tolkes_som: String,
+    val kokriterie: Boolean,
     val verdiforklaringerErUttømmende: Boolean = false,
     val verdiforklaringer: List<Verdiforklaring>?
 )

--- a/src/main/resources/adapterdefinisjoner/k9-feltdefinisjoner-v2.json
+++ b/src/main/resources/adapterdefinisjoner/k9-feltdefinisjoner-v2.json
@@ -3,27 +3,35 @@
   "feltdefinisjoner": [
     {
       "id": "behandlingUuid",
-      "listetype": false,
-      "tolkesSom": "String",
-      "visTilBruker": true
-    },
-    {
-      "id": "påklagdBehandlingUuid",
-      "listetype": false,
-      "tolkesSom": "String",
-      "visTilBruker": true
-    },
-    {
-      "id": "aktorId",
-      "listetype": false,
-      "tolkesSom": "String",
-      "visTilBruker": true
-    },
-    {
-      "id": "fagsystem",
+      "visningsnavn": "Behandling",
       "listetype": false,
       "tolkesSom": "String",
       "visTilBruker": true,
+      "kokriterie": false
+    },
+    {
+      "id": "påklagdBehandlingUuid",
+      "visningsnavn": "Påklaget behandling",
+      "listetype": false,
+      "tolkesSom": "String",
+      "visTilBruker": true,
+      "kokriterie": false
+    },
+    {
+      "id": "aktorId",
+      "visningsnavn": "Søkers aktør-ID",
+      "listetype": false,
+      "tolkesSom": "String",
+      "visTilBruker": false,
+      "kokriterie": false
+    },
+    {
+      "id": "fagsystem",
+      "visningsnavn": "Fagsystem",
+      "listetype": false,
+      "tolkesSom": "String",
+      "visTilBruker": true,
+      "kokriterie": false,
       "kodeverkreferanse": {
         "område": "K9",
         "eksternId": "Fagsystem"
@@ -31,15 +39,19 @@
     },
     {
       "id": "saksnummer",
-      "listetype": false,
-      "tolkesSom": "String",
-      "visTilBruker": true
-    },
-    {
-      "id": "resultattype",
+      "visningsnavn": "Saksnummer",
       "listetype": false,
       "tolkesSom": "String",
       "visTilBruker": true,
+      "kokriterie": false
+    },
+    {
+      "id": "resultattype",
+      "visningsnavn": "Resultattype",
+      "listetype": false,
+      "tolkesSom": "String",
+      "visTilBruker": true,
+      "kokriterie": false,
       "kodeverkreferanse": {
         "område": "K9",
         "eksternId": "Resultattype"
@@ -47,9 +59,11 @@
     },
     {
       "id": "behandlingssteg",
+      "visningsnavn": "Behandlingssteg",
       "listetype": false,
       "tolkesSom": "String",
       "visTilBruker": true,
+      "kokriterie": true,
       "kodeverkreferanse": {
         "område": "K9",
         "eksternId": "Behandlingssteg"
@@ -57,9 +71,11 @@
     },
     {
       "id": "ytelsestype",
+      "visningsnavn": "Ytelsestype",
       "listetype": false,
       "tolkesSom": "String",
       "visTilBruker": true,
+      "kokriterie": true,
       "kodeverkreferanse": {
         "område": "K9",
         "eksternId": "Ytelsetype"
@@ -67,9 +83,11 @@
     },
     {
       "id": "behandlingsstatus",
+      "visningsnavn": "Behandlingsstatus",
       "listetype": false,
       "tolkesSom": "String",
       "visTilBruker": true,
+      "kokriterie": false,
       "kodeverkreferanse": {
         "område": "K9",
         "eksternId": "Behandlingsstatus"
@@ -77,21 +95,27 @@
     },
     {
       "id": "mottattDato",
+      "visningsnavn": "Mottatt dato",
       "listetype": false,
       "tolkesSom": "Timestamp",
-      "visTilBruker": true
+      "visTilBruker": true,
+      "kokriterie": true
     },
     {
       "id": "registrertDato",
+      "visningsnavn": "Registrert dato",
       "listetype": false,
       "tolkesSom": "Timestamp",
-      "visTilBruker": true
+      "visTilBruker": true,
+      "kokriterie": true
     },
     {
       "id": "behandlingTypekode",
+      "visningsnavn": "Behandlingstype",
       "listetype": false,
       "tolkesSom": "String",
       "visTilBruker": true,
+      "kokriterie": true,
       "kodeverkreferanse": {
         "område": "K9",
         "eksternId": "Behandlingtype"
@@ -99,45 +123,59 @@
     },
     {
       "id": "relatertPartAktorid",
+      "visningsnavn": "Relatert part aktør-ID",
       "listetype": false,
       "tolkesSom": "String",
-      "visTilBruker": true
+      "visTilBruker": false,
+      "kokriterie": false
     },
     {
       "id": "pleietrengendeAktorId",
+      "visningsnavn": "Pleietrengende aktør-ID",
       "listetype": false,
       "tolkesSom": "String",
-      "visTilBruker": true
+      "visTilBruker": false,
+      "kokriterie": false
     },
     {
       "id": "behandlendeEnhet",
+      "visningsnavn": "Behandlende enhet",
       "listetype": false,
       "tolkesSom": "String",
-      "visTilBruker": true
+      "visTilBruker": true,
+      "kokriterie": false
     },
     {
       "id": "ansvarligSaksbehandler",
+      "visningsnavn": "Ansvarlig saksbehandler",
       "listetype": false,
       "tolkesSom": "String",
-      "visTilBruker": true
+      "visTilBruker": true,
+      "kokriterie": false
     },
     {
       "id": "ansvarligBeslutter",
+      "visningsnavn": "Ansvarlig beslutter",
       "listetype": false,
       "tolkesSom": "String",
-      "visTilBruker": true
+      "visTilBruker": true,
+      "kokriterie": false
     },
     {
       "id": "totrinnskontroll",
+      "visningsnavn": "Må gjennom totrinnskontroll",
       "listetype": false,
       "tolkesSom": "boolean",
-      "visTilBruker": true
+      "visTilBruker": true,
+      "kokriterie": false
     },
     {
       "id": "aksjonspunkt",
+      "visningsnavn": "Løsbare, fremtidige og tidligere aksjonspunkt",
       "listetype": true,
       "tolkesSom": "String",
       "visTilBruker": true,
+      "kokriterie": true,
       "kodeverkreferanse": {
         "område": "K9",
         "eksternId": "Aksjonspunkt"
@@ -145,9 +183,11 @@
     },
     {
       "id": "aktivtAksjonspunkt",
+      "visningsnavn": "Løsbare og fremtidige aksjonspunkt",
       "listetype": true,
       "tolkesSom": "String",
       "visTilBruker": true,
+      "kokriterie": false,
       "kodeverkreferanse": {
         "område": "K9",
         "eksternId": "Aksjonspunkt"
@@ -155,9 +195,11 @@
     },
     {
       "id": "løsbartAksjonspunkt",
+      "visningsnavn": "Løsbart aksjonspunkt",
       "listetype": false,
       "tolkesSom": "String",
       "visTilBruker": true,
+      "kokriterie": true,
       "kodeverkreferanse": {
         "område": "K9",
         "eksternId": "Aksjonspunkt"
@@ -165,81 +207,107 @@
     },
     {
       "id": "avventerSaksbehandler",
+      "visningsnavn": "Avventer saksbehandler",
       "listetype": false,
       "tolkesSom": "boolean",
-      "visTilBruker": true
+      "visTilBruker": true,
+      "kokriterie": false
     },
     {
       "id": "avventerSøker",
+      "visningsnavn": "Avventer søker",
       "listetype": false,
       "tolkesSom": "boolean",
-      "visTilBruker": true
+      "visTilBruker": true,
+      "kokriterie": false
     },
     {
       "id": "avventerArbeidsgiver",
+      "visningsnavn": "Avventer arbeidsgiver",
       "listetype": false,
       "tolkesSom": "boolean",
-      "visTilBruker": true
+      "visTilBruker": true,
+      "kokriterie": false
     },
     {
       "id": "avventerTekniskFeil",
+      "visningsnavn": "Avventer teknisk feil",
       "listetype": false,
       "tolkesSom": "boolean",
-      "visTilBruker": true
+      "visTilBruker": true,
+      "kokriterie": false
     },
     {
       "id": "avventerAnnet",
+      "visningsnavn": "Avventer annet",
       "listetype": false,
       "tolkesSom": "boolean",
-      "visTilBruker": true
+      "visTilBruker": true,
+      "kokriterie": false
     },
     {
       "id": "avventerAnnetIkkeSaksbehandlingstid",
+      "visningsnavn": "Avventer annet (ikke saksbehandlingstid)",
       "listetype": false,
       "tolkesSom": "boolean",
-      "visTilBruker": true
+      "visTilBruker": true,
+      "kokriterie": false
     },
     {
       "id": "akkumulertVentetidSaksbehandlerForTidligereVersjoner",
+      "visningsnavn": "Akkumulert ventetid saksbehandler for tidligere versjoner",
       "listetype": false,
       "tolkesSom": "Duration",
-      "visTilBruker": true
+      "visTilBruker": false,
+      "kokriterie": false
     },
     {
       "id": "akkumulertVentetidSøkerForTidligereVersjoner",
+      "visningsnavn": "Akkumulert ventetid søker for tidligere versjoner",
       "listetype": false,
       "tolkesSom": "Duration",
-      "visTilBruker": true
+      "visTilBruker": false,
+      "kokriterie": false
     },
     {
       "id": "akkumulertVentetidTekniskFeilForTidligereVersjoner",
+      "visningsnavn": "Akkumulert ventetid teknisk feil for tidligere versjoner",
       "listetype": false,
       "tolkesSom": "Duration",
-      "visTilBruker": true
+      "visTilBruker": false,
+      "kokriterie": false
     },
     {
-    "id": "akkumulertVentetidArbeidsgiverForTidligereVersjoner",
-    "listetype": false,
-    "tolkesSom": "Duration",
-    "visTilBruker": true
+      "id": "akkumulertVentetidArbeidsgiverForTidligereVersjoner",
+      "visningsnavn": "Akkumulert ventetid arbeidsgiver for tidligere versjoner",
+      "listetype": false,
+      "tolkesSom": "Duration",
+      "visTilBruker": false,
+      "kokriterie": false
     },
     {
       "id": "akkumulertVentetidAnnetForTidligereVersjoner",
+      "visningsnavn": "Akkumulert ventetid annet for tidligere versjoner",
       "listetype": false,
       "tolkesSom": "Duration",
-      "visTilBruker": true
+      "visTilBruker": false,
+      "kokriterie": false
     },
     {
       "id": "akkumulertVentetidAnnetIkkeSaksbehandlingstidForTidligereVersjoner",
+      "visningsnavn": "Akkumulert ventetid annet (ikke saksbehandlingstid) for tidligere versjoner",
       "listetype": false,
       "tolkesSom": "Duration",
-      "visTilBruker": true
+      "visTilBruker": false,
+      "kokriterie": false
     },
     {
       "id": "aktivVenteårsak",
+      "visningsnavn": "Aktiv venteårsak",
       "listetype": false,
       "tolkesSom": "String",
       "visTilBruker": true,
+      "kokriterie": false,
       "kodeverkreferanse": {
         "område": "K9",
         "eksternId": "Venteårsak"
@@ -247,39 +315,51 @@
     },
     {
       "id": "aktivVentefrist",
+      "visningsnavn": "Aktiv ventefrist",
       "listetype": false,
       "tolkesSom": "Timestamp",
-      "visTilBruker": true
+      "visTilBruker": true,
+      "kokriterie": false
     },
     {
       "id": "helautomatiskBehandlet",
+      "visningsnavn": "Helautomatisk behandlet",
       "listetype": false,
       "tolkesSom": "boolean",
-      "visTilBruker": true
+      "visTilBruker": true,
+      "kokriterie": false
     },
     {
       "id": "vedtaksdato",
+      "visningsnavn": "Vedtaksdato",
       "listetype": false,
       "tolkesSom": "Timestamp",
-      "visTilBruker": true
+      "visTilBruker": true,
+      "kokriterie": false
     },
     {
       "id": "nyeKrav",
+      "visningsnavn": "Søknad om nye perioder",
       "listetype": false,
       "tolkesSom": "boolean",
-      "visTilBruker": true
+      "visTilBruker": true,
+      "kokriterie": true
     },
     {
       "id": "fraEndringsdialog",
+      "visningsnavn": "Oppdatert gjennom endringsdialog",
       "listetype": false,
       "tolkesSom": "boolean",
-      "visTilBruker": true
+      "visTilBruker": true,
+      "kokriterie": true
     },
     {
       "id": "hastesak",
+      "visningsnavn": "Hastesak",
       "listetype": false,
       "tolkesSom": "boolean",
-      "visTilBruker": true
+      "visTilBruker": true,
+      "kokriterie": true
     }
   ]
 }

--- a/src/main/resources/migreringer/V1.0_0042__nyoppgavestyring-visningsnavn.sql
+++ b/src/main/resources/migreringer/V1.0_0042__nyoppgavestyring-visningsnavn.sql
@@ -1,0 +1,2 @@
+alter table feltdefinisjon add column if not exists visningsnavn varchar(100) NOT NULL DEFAULT '';
+alter table feltdefinisjon add column if not exists kokriterie boolean NOT NULL DEFAULT FALSE;

--- a/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/feltutlederforlagring/AkkumulertVentetidTest.kt
+++ b/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/feltutlederforlagring/AkkumulertVentetidTest.kt
@@ -129,9 +129,11 @@ internal class AkkumulertVentetidTest {
             område = Område(
                 eksternId = "test"
             ),
+            visningsnavn = "Test",
             listetype = false,
             tolkesSom = "Boolean",
             visTilBruker = true,
+            kokriterie = true,
             kodeverkreferanse = null,
         ),
         visPåOppgave = true,

--- a/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/mottak/feltdefinisjon/FeltdefinisjonTest.kt
+++ b/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/mottak/feltdefinisjon/FeltdefinisjonTest.kt
@@ -24,9 +24,11 @@ class FeltdefinisjonTest {
                 Feltdefinisjon(
                     eksternId = "saksnummer",
                     område = område,
+                    visningsnavn = "Test",
                     listetype = false,
                     tolkesSom = "String",
                     visTilBruker = true,
+                    kokriterie = false,
                     kodeverkreferanse = null
                 )
             )
@@ -44,17 +46,21 @@ class FeltdefinisjonTest {
                 Feltdefinisjon(
                     eksternId = "saksnummer",
                     område = område,
+                    visningsnavn = "Test",
                     listetype = true,
                     tolkesSom = "String",
                     visTilBruker = true,
+                    kokriterie = false,
                     kodeverkreferanse = null
                 ),
                 Feltdefinisjon(
                     eksternId = "opprettet",
                     område = område,
+                    visningsnavn = "Test",
                     listetype = true,
                     tolkesSom = "Date",
                     visTilBruker = true,
+                    kokriterie = false,
                     kodeverkreferanse = null
                 )
             )
@@ -72,17 +78,21 @@ class FeltdefinisjonTest {
                 Feltdefinisjon(
                     eksternId = "saksnummer",
                     område = område,
+                    visningsnavn = "Test",
                     listetype = false,
                     tolkesSom = "String",
                     visTilBruker = true,
+                    kokriterie = false,
                     kodeverkreferanse = null
                 ),
                 Feltdefinisjon(
                     eksternId = "opprettet",
                     område = område,
+                    visningsnavn = "Test",
                     listetype = false,
                     tolkesSom = "Date",
                     visTilBruker = true,
+                    kokriterie = false,
                     kodeverkreferanse = null
                 )
             )

--- a/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/mottak/feltdefinisjon/KodeverkTest.kt
+++ b/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/mottak/feltdefinisjon/KodeverkTest.kt
@@ -73,10 +73,12 @@ class KodeverkTest : AbstractK9LosIntegrationTest() {
          return Feltdefinisjon(
              id = null,
              eksternId = testFeltdefinissjonEksternId,
+             visningsnavn = "Test",
              område = område,
              listetype = false,
              tolkesSom = "String",
              visTilBruker = true,
+             kokriterie = false,
              kodeverkreferanse = kodeverkreferanse
          )
     }

--- a/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/mottak/oppgave/OppgaveV3Test.kt
+++ b/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/mottak/oppgave/OppgaveV3Test.kt
@@ -105,36 +105,46 @@ class OppgaveV3Test : AbstractK9LosIntegrationTest() {
             feltdefinisjoner = setOf(
                 FeltdefinisjonDto(
                     id = "aksjonspunkt",
+                    visningsnavn = "Test",
                     listetype = true,
                     tolkesSom = "String",
                     true,
+                    false,
                     kodeverkreferanse = null
                 ),
                 FeltdefinisjonDto(
                     id = "opprettet",
+                    visningsnavn = "Test",
                     listetype = false,
                     tolkesSom = "Date",
                     true,
+                    false,
                     kodeverkreferanse = null
                 ),
                 FeltdefinisjonDto(
                     id = "aktorId",
+                    visningsnavn = "Test",
                     listetype = false,
                     tolkesSom = "String",
                     true,
+                    false,
                     kodeverkreferanse = null
                 ),
                 FeltdefinisjonDto(
                     id = "akkumulertVentetidSaksbehandler",
+                    visningsnavn = "Test",
                     listetype = false,
                     tolkesSom = "Duration",
+                    false,
                     false,
                     kodeverkreferanse = null
                 ),
                 FeltdefinisjonDto(
                     id = "avventerSaksbehandler",
+                    visningsnavn = "Test",
                     listetype = false,
                     tolkesSom = "boolean",
+                    false,
                     false,
                     kodeverkreferanse = null
                 )

--- a/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/mottak/oppgavetype/OppgavetypeTest.kt
+++ b/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/mottak/oppgavetype/OppgavetypeTest.kt
@@ -71,9 +71,11 @@ class OppgavetypeTest {
                             Feltdefinisjon(
                                 eksternId = "saksnummer",
                                 område = område,
+                                visningsnavn = "Test",
                                 listetype = false,
                                 tolkesSom = "String",
                                 visTilBruker = true,
+                                kokriterie = false,
                                 kodeverkreferanse = null
                             ),
                             visPåOppgave = true,
@@ -85,9 +87,11 @@ class OppgavetypeTest {
                             feltDefinisjon = Feltdefinisjon(
                                 eksternId = "saksnummer",
                                 område = område,
+                                visningsnavn = "Test",
                                 listetype = false,
                                 tolkesSom = "String",
                                 visTilBruker = true,
+                                kokriterie = false,
                                 kodeverkreferanse = null
                             ),
                             visPåOppgave = true,
@@ -120,9 +124,11 @@ class OppgavetypeTest {
                             feltDefinisjon = Feltdefinisjon(
                                 eksternId = "saksnummer",
                                 område = område,
+                                visningsnavn = "Test",
                                 listetype = false,
                                 tolkesSom = "String",
                                 visTilBruker = true,
+                                kokriterie = false,
                                 kodeverkreferanse = null
                             ),
                             visPåOppgave = true,
@@ -134,9 +140,11 @@ class OppgavetypeTest {
                             feltDefinisjon = Feltdefinisjon(
                                 eksternId = "saksnummer",
                                 område = område,
+                                visningsnavn = "Test",
                                 listetype = false,
                                 tolkesSom = "String",
                                 visTilBruker = true,
+                                kokriterie = false,
                                 kodeverkreferanse = null
                             ),
                             visPåOppgave = true,
@@ -148,9 +156,11 @@ class OppgavetypeTest {
                             feltDefinisjon = Feltdefinisjon(
                                 eksternId = "aktorId",
                                 område = område,
+                                visningsnavn = "Test",
                                 listetype = false,
                                 tolkesSom = "String",
                                 visTilBruker = true,
+                                kokriterie = false,
                                 kodeverkreferanse = null
                             ),
                             visPåOppgave = true,
@@ -169,9 +179,11 @@ class OppgavetypeTest {
                             feltDefinisjon = Feltdefinisjon(
                                 eksternId = "saksnummer",
                                 område = område,
+                                visningsnavn = "Test",
                                 listetype = false,
                                 tolkesSom = "String",
                                 visTilBruker = true,
+                                kokriterie = false,
                                 kodeverkreferanse = null
                             ),
                             visPåOppgave = true,
@@ -204,9 +216,11 @@ class OppgavetypeTest {
                             feltDefinisjon = Feltdefinisjon(
                                 eksternId = "saksnummer",
                                 område = område,
+                                visningsnavn = "Test",
                                 listetype = false,
                                 tolkesSom = "String",
                                 visTilBruker = true,
+                                kokriterie = false,
                                 kodeverkreferanse = null
                             ),
                             visPåOppgave = true,
@@ -218,9 +232,11 @@ class OppgavetypeTest {
                             feltDefinisjon = Feltdefinisjon(
                                 eksternId = "saksnummer",
                                 område = område,
+                                visningsnavn = "Test",
                                 listetype = false,
                                 tolkesSom = "String",
                                 visTilBruker = true,
+                                kokriterie = false,
                                 kodeverkreferanse = null
                             ),
                             visPåOppgave = true,
@@ -232,9 +248,11 @@ class OppgavetypeTest {
                             feltDefinisjon = Feltdefinisjon(
                                 eksternId = "testverdi",
                                 område = område,
+                                visningsnavn = "Test",
                                 listetype = false,
                                 tolkesSom = "String",
                                 visTilBruker = true,
+                                kokriterie = false,
                                 kodeverkreferanse = null
                             ),
                             visPåOppgave = true,
@@ -253,9 +271,11 @@ class OppgavetypeTest {
                             feltDefinisjon = Feltdefinisjon(
                                 eksternId = "saksnummer",
                                 område = område,
+                                visningsnavn = "Test",
                                 listetype = false,
                                 tolkesSom = "String",
                                 visTilBruker = true,
+                                kokriterie = false,
                                 kodeverkreferanse = null
                             ),
                             visPåOppgave = true,


### PR DESCRIPTION
Rydder i tillegg opp i visTilBruker og legger til nytt felt kokritere. Sistnevnte brukes for å kun vise relevante felter ved opprettelse av køer.