### PR TITLE
Håndterer at klageaksjonspunkter ikke skal overlappe med k9-sak.

### DIFF
--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/OmrådeSetup.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/OmrådeSetup.kt
@@ -10,6 +10,7 @@ import no.nav.k9.los.domene.modell.BehandlingType
 import no.nav.k9.los.domene.modell.FagsakYtelseType
 import no.nav.k9.los.domene.modell.Fagsystem
 import no.nav.k9.los.nyoppgavestyring.domeneadaptere.k9.saktillos.K9SakTilLosAdapterTjeneste
+import no.nav.k9.los.nyoppgavestyring.domeneadaptere.k9klagetillos.EventTilDtoMapper
 import no.nav.k9.los.nyoppgavestyring.mottak.feltdefinisjon.FeltdefinisjonTjeneste
 import no.nav.k9.los.nyoppgavestyring.mottak.feltdefinisjon.FeltdefinisjonerDto
 import no.nav.k9.los.nyoppgavestyring.mottak.feltdefinisjon.KodeverkDto
@@ -64,16 +65,30 @@ class OmrådeSetup(
             eksternId = "Aksjonspunkt",
             beskrivelse = null,
             uttømmende = false,
-            verdier = AksjonspunktDefinisjon.values().filterNot { it == AksjonspunktDefinisjon.UNDEFINED }.map { apDefinisjon ->
-                KodeverkVerdiDto(
-                    verdi = apDefinisjon.kode,
-                    visningsnavn = apDefinisjon.navn,
-                    beskrivelse = null,
-                )
-            }
+            verdier = aksjonspunktVerdierK9Sak().plus(aksjonspunktVerdierK9Klage())
         )
         feltdefinisjonTjeneste.oppdater(kodeverkDto)
     }
+
+    private fun aksjonspunktVerdierK9Sak() =
+        AksjonspunktDefinisjon.values().filterNot { it == AksjonspunktDefinisjon.UNDEFINED }.map { apDefinisjon ->
+            KodeverkVerdiDto(
+                verdi = apDefinisjon.kode,
+                visningsnavn = apDefinisjon.navn,
+                beskrivelse = null,
+            )
+        }
+
+    private fun aksjonspunktVerdierK9Klage() =
+        no.nav.k9.klage.kodeverk.behandling.aksjonspunkt.AksjonspunktDefinisjon.values()
+        .filterNot { it == no.nav.k9.klage.kodeverk.behandling.aksjonspunkt.AksjonspunktDefinisjon.UNDEFINED }
+        .map { apDefinisjon ->
+            KodeverkVerdiDto(
+                verdi = EventTilDtoMapper.AKSJONSPUNKT_PREFIX + apDefinisjon.kode,
+                visningsnavn = apDefinisjon.navn,
+                beskrivelse = null,
+            )
+        }
 
     private fun kodeverkFagsystem() {
         val kodeverkDto = KodeverkDto(

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/klagetillos/EventTilDtoMapper.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/klagetillos/EventTilDtoMapper.kt
@@ -14,7 +14,10 @@ import no.nav.k9.los.nyoppgavestyring.mottak.oppgave.OppgaveV3
 import no.nav.k9.los.nyoppgavestyring.mottak.oppgave.Oppgavestatus
 
 class EventTilDtoMapper {
+
     companion object {
+        const val AKSJONSPUNKT_PREFIX = "KLAGE"
+
         private val MANUELLE_AKSJONSPUNKTER = AksjonspunktDefinisjon.values().filter { aksjonspunktDefinisjon ->
             aksjonspunktDefinisjon.aksjonspunktType == AksjonspunktType.MANUELL
         }.map { aksjonspunktDefinisjon -> aksjonspunktDefinisjon.kode }
@@ -112,6 +115,8 @@ class EventTilDtoMapper {
 
             utledAksjonspunkter(event, oppgaveFeltverdiDtos)
             utledÅpneAksjonspunkter(åpneAksjonspunkter, oppgaveFeltverdiDtos)
+            utledLøsbartAksjonspunkt(event.behandlingSteg, åpneAksjonspunkter, oppgaveFeltverdiDtos)
+
             //automatiskBehandletFlagg er defaultet til False p.t.
             utledAvventerSaksbehandler(harManueltAksjonspunkt, harAutopunkt, oppgaveFeltverdiDtos)
 
@@ -132,7 +137,7 @@ class EventTilDtoMapper {
                     oppgaveFeltverdiDtos.add(
                         OppgaveFeltverdiDto(
                             nøkkel = "aktivtAksjonspunkt",
-                            verdi = åpentAksjonspunkt.aksjonspunktKode
+                            verdi = AKSJONSPUNKT_PREFIX + åpentAksjonspunkt.aksjonspunktKode
                         )
                     )
                 }
@@ -146,6 +151,24 @@ class EventTilDtoMapper {
             }
         }
 
+        private fun utledLøsbartAksjonspunkt(
+            behandlingSteg: String,
+            åpneAksjonspunkter: List<Aksjonspunkttilstand>,
+            oppgaveFeltverdiDtos: MutableList<OppgaveFeltverdiDto>
+        ) {
+            åpneAksjonspunkter.firstOrNull { åpentAksjonspunkt ->
+                val aksjonspunktDefinisjon = no.nav.k9.kodeverk.behandling.aksjonspunkt.AksjonspunktDefinisjon.fraKode(åpentAksjonspunkt.aksjonspunktKode)
+                !aksjonspunktDefinisjon.erAutopunkt() && aksjonspunktDefinisjon.behandlingSteg != null && aksjonspunktDefinisjon.behandlingSteg.kode == behandlingSteg
+            }?.let {
+                oppgaveFeltverdiDtos.add(
+                    OppgaveFeltverdiDto(
+                        nøkkel = "løsbartAksjonspunkt",
+                        verdi = AKSJONSPUNKT_PREFIX + it.aksjonspunktKode
+                    )
+                )
+            }
+        }
+
         private fun utledAksjonspunkter(
             event: KlagebehandlingProsessHendelse,
             oppgaveFeltverdiDtos: MutableList<OppgaveFeltverdiDto>
@@ -154,7 +177,7 @@ class EventTilDtoMapper {
                 oppgaveFeltverdiDtos.addAll(event.aksjonspunkttilstander.map { aksjonspunkttilstand ->
                     OppgaveFeltverdiDto(
                         nøkkel = "aksjonspunkt",
-                        verdi = aksjonspunkttilstand.aksjonspunktKode
+                        verdi = AKSJONSPUNKT_PREFIX + aksjonspunkttilstand.aksjonspunktKode
                     )
                 })
             } else {

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/klagetillos/K9KlageTilLosHistorikkvaskTjeneste.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/klagetillos/K9KlageTilLosHistorikkvaskTjeneste.kt
@@ -35,13 +35,6 @@ class K9KlageTilLosHistorikkvaskTjeneste(
 
     private val log: Logger = LoggerFactory.getLogger(K9KlageTilLosHistorikkvaskTjeneste::class.java)
     private val TRÅDNAVN = "k9-klage-til-los-historikkvask"
-    private val MANUELLE_AKSJONSPUNKTER = AksjonspunktDefinisjon.values().filter { aksjonspunktDefinisjon ->
-        aksjonspunktDefinisjon.aksjonspunktType == AksjonspunktType.MANUELL
-    }.map { aksjonspunktDefinisjon -> aksjonspunktDefinisjon.kode }
-
-    private val AUTOPUNKTER = AksjonspunktDefinisjon.values().filter { aksjonspunktDefinisjon ->
-        aksjonspunktDefinisjon.aksjonspunktType == AksjonspunktType.AUTOPUNKT
-    }.map { aksjonspunktDefinisjon -> aksjonspunktDefinisjon.kode }
 
     fun kjørHistorikkvask() {
         if (config.nyOppgavestyringAktivert()) {

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/statistikk/K9KlageOppgaveTilDVHMapper.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/statistikk/K9KlageOppgaveTilDVHMapper.kt
@@ -3,7 +3,9 @@ package no.nav.k9.los.nyoppgavestyring.domeneadaptere.k9.statistikk
 import no.nav.k9.klage.kodeverk.behandling.BehandlingResultatType
 import no.nav.k9.klage.kodeverk.behandling.BehandlingStatus
 import no.nav.k9.klage.kodeverk.behandling.FagsakYtelseType
+import no.nav.k9.klage.kodeverk.behandling.aksjonspunkt.AksjonspunktDefinisjon
 import no.nav.k9.los.domene.modell.BehandlingType
+import no.nav.k9.los.nyoppgavestyring.domeneadaptere.k9klagetillos.EventTilDtoMapper
 import no.nav.k9.los.nyoppgavestyring.visningoguttrekk.Oppgave
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -57,7 +59,7 @@ class K9KlageOppgaveTilDVHMapper {
     }
 
     private fun utledBehandlingStatus(oppgave: Oppgave): String {
-        return if (oppgave.hentListeverdi("aktivtAksjonspunkt").contains("AUTO_OVERFØRT_NK")) {
+        return if (oppgave.hentListeverdi("aktivtAksjonspunkt").contains(EventTilDtoMapper.AKSJONSPUNKT_PREFIX + AksjonspunktDefinisjon.AUTO_OVERFØRT_NK.kode)) {
             "OVERFORT_KLAGE_ANKE"
         } else {
             BehandlingStatus.fraKode(oppgave.hentVerdi("behandlingsstatus")).kode

--- a/src/main/resources/adapterdefinisjoner/k9-oppgavetyper-k9klage.json
+++ b/src/main/resources/adapterdefinisjoner/k9-oppgavetyper-k9klage.json
@@ -111,6 +111,11 @@
           "påkrevd": false
         },
         {
+          "id": "løsbartAksjonspunkt",
+          "visPåOppgave": true,
+          "påkrevd": false
+        },
+        {
           "id": "avventerSaksbehandler",
           "visPåOppgave": true,
           "påkrevd": true


### PR DESCRIPTION
Retter referanse til aksjonspunkt ved oversending til statistikk.