### PR TITLE
Fjerner valg av beskyttelsetype i frontend

### DIFF
--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/kodeverk/BeskyttelseType.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/kodeverk/BeskyttelseType.kt
@@ -3,7 +3,6 @@ package no.nav.k9.los.nyoppgavestyring.kodeverk
 import com.fasterxml.jackson.annotation.JsonCreator
 
 enum class BeskyttelseType(val kode: String, val beskrivelse: String) {
-    KODE6("KODE6", "Kode 6"),
     KODE7("KODE7", "Kode 7"),
     ORDINÆR("ORDINÆR", "Vanlig");
 

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/query/db/SqlOppgaveQuery.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/query/db/SqlOppgaveQuery.kt
@@ -103,9 +103,8 @@ class SqlOppgaveQuery(
             }
             "beskyttelse" -> {
                 when(feltverdi) {
-                    BeskyttelseType.KODE6.kode -> query += "${combineOperator.sql} opc.kode6 is true "
                     BeskyttelseType.KODE7.kode -> query += "${combineOperator.sql} opc.kode7 is true "
-                    BeskyttelseType.ORDINÆR.kode -> {
+                    else -> {
                         query += "${combineOperator.sql} opc.kode6 is not true AND opc.kode7 is not true "
                     }
                 }

--- a/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/pep/PepCacheServiceTest.kt
+++ b/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/pep/PepCacheServiceTest.kt
@@ -165,18 +165,19 @@ class PepCacheServiceTest : KoinTest, AbstractPostgresTest() {
         val eksternId = UUID.randomUUID().toString()
         k9sakEventHandler.prosesser(lagBehandlingprosessEventMedStatus(eksternId, saksnummer))
 
-        assertThat(hentOppgaverMedSikkerhetsklassifisering(oppgaveQueryService, eksternId, BeskyttelseType.ORDINÆR)).isNotEmpty()
+        assertThat(hentOppgaverMedSikkerhetsklassifisering(oppgaveQueryService, eksternId, BeskyttelseType.ORDINÆR.kode)).isNotEmpty()
         assertThat(hentOppgaverMedSikkerhetsklassifisering(oppgaveQueryService, eksternId)).isNotEmpty()
-        assertThat(hentOppgaverMedSikkerhetsklassifisering(oppgaveQueryService, eksternId, BeskyttelseType.KODE6)).isEmpty()
+        assertThat(hentOppgaverMedSikkerhetsklassifisering(oppgaveQueryService, eksternId, "KODE6")).isNotEmpty() // Samme som ordinær frem til håndtert. Kan f.eks gjeninnføres som egen interntype som ikke eksponeres ut
 
-        verify(exactly = 2) { runBlocking { pepClient.harTilgangTilLesSak(eq(saksnummer), any()) } }
+        verify(exactly = 3) { runBlocking { pepClient.harTilgangTilLesSak(eq(saksnummer), any()) } }
 
         gjørSakKode6(saksnummer)
         ventPåAntallForsøk(10, "Pepcache") { pepRepository.hent("K9", eksternId)?.kode6 == true }
 
-        assertThat(hentOppgaverMedSikkerhetsklassifisering(oppgaveQueryService, eksternId, BeskyttelseType.ORDINÆR)).isEmpty()
-        assertThat(hentOppgaverMedSikkerhetsklassifisering(oppgaveQueryService, eksternId)).isNotEmpty()  // Alle beskyttelsetyper er inkludert hvis ikke beksyttelsetype er spesifisert
-        assertThat(hentOppgaverMedSikkerhetsklassifisering(oppgaveQueryService, eksternId, BeskyttelseType.KODE6)).isNotEmpty()
+        assertThat(hentOppgaverMedSikkerhetsklassifisering(oppgaveQueryService, eksternId, BeskyttelseType.ORDINÆR.kode)).isEmpty()
+        assertThat(hentOppgaverMedSikkerhetsklassifisering(oppgaveQueryService, eksternId)).isNotEmpty()  // Alle beskyttelsetyper er inkludert hvis ikke beskyttelsetype er spesifisert
+        assertThat(hentOppgaverMedSikkerhetsklassifisering(oppgaveQueryService, eksternId, "KODE6")).isEmpty() // Samme som ordinær frem til håndtert
+
 
         job.cancel()
         verify(exactly = 4) { runBlocking { pepClient.harTilgangTilLesSak(eq(saksnummer), any()) } }
@@ -200,7 +201,7 @@ class PepCacheServiceTest : KoinTest, AbstractPostgresTest() {
     private fun hentOppgaverMedSikkerhetsklassifisering(
         oppgaveQueryService: OppgaveQueryService,
         eksternId: String,
-        vararg sikkerhetsklassifiseringtyper: BeskyttelseType
+        vararg sikkerhetsklassifiseringtyper: String
     ): List<Any> {
         val transactionalManager = get<TransactionalManager>()
         return transactionalManager.transaction { tx ->
@@ -210,7 +211,7 @@ class PepCacheServiceTest : KoinTest, AbstractPostgresTest() {
                         område = null,
                         kode = FeltType.BESKYTTELSE.eksternId,
                         operator = "IN",
-                        verdi = sikkerhetsklassifiseringtyper.map { it.kode }
+                        verdi = sikkerhetsklassifiseringtyper.toList()
                     ),
                     FeltverdiOppgavefilter(område = "K9",
                         kode = FeltType.BEHANDLINGUUID.eksternId,

--- a/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/query/OppgaveQueryTest.kt
+++ b/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/query/OppgaveQueryTest.kt
@@ -24,6 +24,7 @@ import no.nav.k9.los.nyoppgavestyring.query.dto.query.CombineOppgavefilter
 import no.nav.k9.los.nyoppgavestyring.query.dto.query.FeltverdiOppgavefilter
 import no.nav.k9.los.nyoppgavestyring.query.dto.query.OppgaveQuery
 import no.nav.k9.los.nyoppgavestyring.visningoguttrekk.OppgaveRepository
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.koin.test.get
 import org.slf4j.Logger
@@ -293,6 +294,7 @@ class OppgaveQueryTest : AbstractK9LosIntegrationTest() {
     }
 
     @Test
+    @Disabled
     fun `Resultat skal kun inneholde kode6-oppgaver når filtre er satt til kode6`() {
         val eksternId = lagOppgave(kode6 = true)
 
@@ -301,7 +303,7 @@ class OppgaveQueryTest : AbstractK9LosIntegrationTest() {
         val oppgaveQueryRepository = OppgaveQueryRepository(dataSource, mockk<FeltdefinisjonRepository>())
         val query = OppgaveQuery(listOf(
             byggFilterK9(FeltType.BEHANDLINGUUID, FeltverdiOperator.EQUALS, eksternId),
-            byggGenereltFilter(FeltType.BESKYTTELSE, FeltverdiOperator.IN, BeskyttelseType.KODE6.kode)
+            byggGenereltFilter(FeltType.BESKYTTELSE, FeltverdiOperator.IN, "KODE6")
         ))
 
         assertThat(oppgaveQueryRepository.query(query)).isNotEmpty()
@@ -324,6 +326,7 @@ class OppgaveQueryTest : AbstractK9LosIntegrationTest() {
     }
 
     @Test
+    @Disabled
     fun `Resultat skal ikke inneholde kode7 eller ordinære oppgaver når filtre er satt til kode6 oppgaver`() {
         val eksternId7 = lagOppgave(kode7 = true)
         val eksternIdOrdinær = lagOppgave()
@@ -333,7 +336,7 @@ class OppgaveQueryTest : AbstractK9LosIntegrationTest() {
         val oppgaveQueryRepository = OppgaveQueryRepository(dataSource, mockk<FeltdefinisjonRepository>())
         val query = OppgaveQuery(listOf(
             byggFilterK9(FeltType.BEHANDLINGUUID, FeltverdiOperator.EQUALS, eksternId7, eksternIdOrdinær),
-            byggGenereltFilter(FeltType.BESKYTTELSE, FeltverdiOperator.IN, BeskyttelseType.KODE6.kode)
+            byggGenereltFilter(FeltType.BESKYTTELSE, FeltverdiOperator.IN, "KODE6")
         ))
 
         assertThat(oppgaveQueryRepository.query(query)).isEmpty()


### PR DESCRIPTION
Hvis sendt med i filter, kjøres spørring som om ordinær er valgt. Kan f.eks gjeninnføres i query ved at backend selv setter den basert på disk. til avd.leder som eier/oppretter køen