### PR TITLE
Prodfeil: Reserverte oppgaver blir liggende i "neste 10 oppgaver" og blokkerer for plukking

### DIFF
--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/reservasjon/ReservasjonV3.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/reservasjon/ReservasjonV3.kt
@@ -64,6 +64,10 @@ class ReservasjonV3(
         gyldigTil = gyldigTil,
     )
 
+    fun erAktiv(): Boolean {
+        return !annullertFørUtløp || gyldigTil.isAfter(LocalDateTime.now())
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/src/main/kotlin/no/nav/k9/los/tjenester/innsikt/Innsikt.kt
+++ b/src/main/kotlin/no/nav/k9/los/tjenester/innsikt/Innsikt.kt
@@ -440,7 +440,7 @@ fun Route.innsiktGrensesnitt() {
             val aktiveV3Reservasjoner = reservasjonv3Tjeneste.hentAlleAktiveReservasjoner()
 
             val aktiveV3ReservasjonerForV1Oppgaver = aktiveV3Reservasjoner
-                .associateWith { it.oppgaverV3.map { UUID.fromString(it.eksternId)!! }.takeIf { it.isNotEmpty() } ?: listOf(it.oppgaveV1!!.eksternId) }
+                .associateWith { it.eksternId() }
 
             val aktiveV1nøkler = aktiveV1Reservasjoner.keys
             val resultatv3ReservasjonerSomIkkeFinnesIV1 = aktiveV3ReservasjonerForV1Oppgaver.filter { (_, eksternIder) -> eksternIder.none { aktiveV1nøkler.contains(it) }}
@@ -672,11 +672,11 @@ fun UL.listeelement(innhold: String, href: String? = null) = li {
 }
 
 fun ReservasjonV3MedOppgaver.eksternId(): List<UUID> {
-    return oppgaverV3.map { UUID.fromString(it.eksternId)!! }.takeIf { it.isNotEmpty() } ?: listOf(oppgaveV1!!.eksternId)
+    return oppgaverV3.map { UUID.fromString(it.eksternId) }.takeIf { it.isNotEmpty() } ?: listOfNotNull(oppgaveV1?.eksternId)
 }
 
 fun ReservasjonV3MedOppgaver.saksnummer(): List<String> {
-    return oppgaverV3.map { it.hentVerdi("saksnummer")!! }.takeIf { it.isNotEmpty() } ?: listOf(oppgaveV1!!.fagsakSaksnummer)
+    return oppgaverV3.mapNotNull { it.hentVerdi("saksnummer") }.takeIf { it.isNotEmpty() } ?: listOfNotNull(oppgaveV1?.fagsakSaksnummer)
 }
 
 fun ReservasjonV3MedOppgaver.utledFraReservasjonsnøkkel(): String {

--- a/src/main/kotlin/no/nav/k9/los/tjenester/saksbehandler/oppgave/OppgaveTjeneste.kt
+++ b/src/main/kotlin/no/nav/k9/los/tjenester/saksbehandler/oppgave/OppgaveTjeneste.kt
@@ -709,6 +709,12 @@ class OppgaveTjeneste constructor(
                         continue
                     }
 
+                    // Sjekker om det finnes en v3-reservasjon. F.eks ved retur fra beslutter der v1-reservasjonen er annullert mens v3-reservasjonen reaktiveres
+                    if (reservasjonOversetter.hentAktivReservasjonFraGammelKontekst(oppgave)?.erAktiv() == true) {
+                        log.info("OppgaveFraKø: Reservasjon v1 er ute av synk med v3. Fjerner oppgave med eksisterende v3-reservasjon fra kandidater ${oppgave.eksternId}")
+                        continue
+                    }
+
                     val person = pdlService.person(oppgave.aktorId)
 
                     val navn = if (person.person != null) person.person.navn() else "Uten navn"
@@ -957,8 +963,7 @@ class OppgaveTjeneste constructor(
         }
 
         // sjekker også om parsakene har blitt besluttet av beslutter
-        if (oppgaverSomSkalBliReservert.map { it.oppgave }
-                .any { innloggetSaksbehandlerHarBesluttetOppgaven(it, brukerident) }) {
+        if (oppgaverSomSkalBliReservert.any { innloggetSaksbehandlerHarBesluttetOppgaven(it.oppgave, brukerident) }) {
             log.info("OppgaveFraKø: Innlogget Saksbehandler har besluttet parsak")
             oppgaverSomErBlokert.add(oppgaveDto)
             return fåOppgaveFraKø(
@@ -970,8 +975,8 @@ class OppgaveTjeneste constructor(
         }
 
         // sjekker også om parsakene har blitt saksbehandlet av saksbehandler
-        if (oppgaverSomSkalBliReservert.map { it.oppgave }
-                .any { innloggetSaksbehandlerHarSaksbehandletOppgaveSomSkalBliBesluttet(it, brukerident) }) {
+        if (oppgaverSomSkalBliReservert
+                .any { innloggetSaksbehandlerHarSaksbehandletOppgaveSomSkalBliBesluttet(it.oppgave, brukerident) }) {
             log.info("OppgaveFraKø: Innlogget beslutter har saksbehandlet parsak")
             oppgaverSomErBlokert.add(oppgaveDto)
             return fåOppgaveFraKø(

--- a/src/test/kotlin/no/nav/k9/los/aksjonspunktbehandling/BeslutterSkalIkkePlukkeEgenSakTest.kt
+++ b/src/test/kotlin/no/nav/k9/los/aksjonspunktbehandling/BeslutterSkalIkkePlukkeEgenSakTest.kt
@@ -1,7 +1,10 @@
 package no.nav.k9.los.aksjonspunktbehandling
 
+import io.mockk.every
+import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import no.nav.k9.los.AbstractK9LosIntegrationTest
+import no.nav.k9.los.Configuration
 import no.nav.k9.los.domene.lager.oppgave.Oppgave
 import no.nav.k9.los.domene.lager.oppgave.v2.OppgaveRepositoryV2
 import no.nav.k9.los.domene.modell.AksjonspunktStatus
@@ -13,8 +16,12 @@ import no.nav.k9.los.domene.modell.Enhet
 import no.nav.k9.los.domene.modell.FagsakYtelseType
 import no.nav.k9.los.domene.modell.KøSortering
 import no.nav.k9.los.domene.modell.OppgaveKø
-import no.nav.k9.los.domene.repository.OppgaveKøRepository
-import no.nav.k9.los.domene.repository.OppgaveRepository
+import no.nav.k9.los.domene.repository.*
+import no.nav.k9.los.integrasjon.abac.IPepClient
+import no.nav.k9.los.integrasjon.azuregraph.IAzureGraphService
+import no.nav.k9.los.integrasjon.pdl.IPdlService
+import no.nav.k9.los.nyoppgavestyring.domeneadaptere.k9.reservasjonkonvertering.ReservasjonOversetter
+import no.nav.k9.los.nyoppgavestyring.reservasjon.ReservasjonV3
 import no.nav.k9.los.tjenester.saksbehandler.oppgave.OppgaveTjeneste
 import org.junit.jupiter.api.Test
 import org.koin.test.get
@@ -32,7 +39,7 @@ class BeslutterSkalIkkePlukkeEgenSakTest : AbstractK9LosIntegrationTest() {
         val oppgaveRepositoryV2 = get<OppgaveRepositoryV2>()
         val oppgaveKøRepository = get<OppgaveKøRepository>()
 
-        val oppgaveTjeneste = get<OppgaveTjeneste>()
+        val oppgaveTjeneste = lagOppgaveTjenesteMedMocketV3Kobling()
         val oppgave = Oppgave(
             behandlingId = null,
             fagsakSaksnummer = "123456",
@@ -108,4 +115,32 @@ class BeslutterSkalIkkePlukkeEgenSakTest : AbstractK9LosIntegrationTest() {
         assertSame(1, nesteOppgaverIKø.size )
     }
 
+
+    private fun lagOppgaveTjenesteMedMocketV3Kobling(): OppgaveTjeneste {
+        val oversetterMock = mockk<ReservasjonOversetter>()
+        every { oversetterMock.hentAktivReservasjonFraGammelKontekst(any()) } returns null
+        every {
+            oversetterMock.taNyReservasjonFraGammelKontekst(any(), any(), any(), any(), any())
+        } returns ReservasjonV3(
+            reservertAv = 123,
+            reservasjonsnøkkel = "test1",
+            gyldigFra = LocalDateTime.now(),
+            gyldigTil = LocalDateTime.now().plusDays(1).plusMinutes(1),
+            kommentar = ""
+        )
+
+        return OppgaveTjeneste(
+            get<OppgaveRepository>(),
+            get<OppgaveRepositoryV2>(),
+            get<OppgaveKøRepository>(),
+            get<SaksbehandlerRepository>(),
+            get<IPdlService>(),
+            get<ReservasjonRepository>(),
+            get<Configuration>(),
+            get<IAzureGraphService>(),
+            get<IPepClient>(),
+            get<StatistikkRepository>(),
+            oversetterMock,
+        )
+    }
 }

--- a/src/test/kotlin/no/nav/k9/los/tjenester/saksbehandler/oppgave/OppgaveTjenesteSettSkjermetTest.kt
+++ b/src/test/kotlin/no/nav/k9/los/tjenester/saksbehandler/oppgave/OppgaveTjenesteSettSkjermetTest.kt
@@ -96,7 +96,9 @@ class OppgaveTjenesteSettSkjermetTest : KoinTest, AbstractPostgresTest() {
             saksbehandlerRepository = saksbehandlerRepository
         )
 
-        val reservasjonOversetter = get<ReservasjonOversetter>()
+        val reservasjonOversetter = mockk<ReservasjonOversetter>()
+        every { reservasjonOversetter.hentAktivReservasjonFraGammelKontekst(any()) } returns null
+
         val config = mockk<Configuration>()
         val pdlService = mockk<PdlService>()
         val statistikkRepository = StatistikkRepository(dataSource = get())
@@ -428,7 +430,9 @@ class OppgaveTjenesteSettSkjermetTest : KoinTest, AbstractPostgresTest() {
             refreshKlienter = refreshKlienter,
             saksbehandlerRepository = saksbehandlerRepository
         )
-        val reservasjonOversetter = get<ReservasjonOversetter>()
+
+        val reservasjonOversetter = mockk<ReservasjonOversetter>()
+        every { reservasjonOversetter.hentAktivReservasjonFraGammelKontekst(any()) } returns null
         val config = mockk<Configuration>()
         val pdlService = mockk<PdlService>()
         val statistikkRepository = StatistikkRepository(dataSource = dataSource)


### PR DESCRIPTION
Når oppgave sendes til beslutter blir saksbehandler-reservasjon slettet i gammel modell og skjult i ny modell. Beslutter-reservasjon opprettes deretter for både ny og gammel modell.

Hvis oppgaven sendes i retur, reaktiveres saksbehandler-reservasjon i ny modell, og saksbehandler får oppgaven rett inn på benken uten å få mulighet til å plukke/ta reservasjon i gammel modell. Gamle køer må derfor også filtrere bort reservasjoner i ny modell siden den er master.

Fjerner det fra køene etter køoppdatering (leggTilOgFjerning) for å ikke blande sammen modellene mer enn de allerede er.