### PR TITLE
Partiell indeks i oppgavefelt_verdi. Bygger tom indeks før historikkvask, utrullingssteg 2

### DIFF
--- a/src/main/resources/migreringer/V1.0_0052__partiell_indeks_oppgavefelt_verdi.sql
+++ b/src/main/resources/migreringer/V1.0_0052__partiell_indeks_oppgavefelt_verdi.sql
@@ -1,0 +1,1 @@
+create index oppgavefelt_verdi_verdi_oppgavefelt_id_oppgave_id_partiell on public.oppgavefelt_verdi using btree (verdi, oppgavefelt_id, oppgave_id) where aktiv = true and oppgavestatus in ('AAPEN', 'VENTER')


### PR DESCRIPTION
Har testet litt i Q, og omskriving av spørringer til å bruke nye kolonner utgjør en stor forbedring. Det ser også ut til å at det går fortere å bygge indeksen når det ikke er noen rader i tabellen som tilfredsstiller predikatet, og det dermed blir en tom indeks