### PR TITLE
Eventhandler håndterte ikke at k9-sak sender venteårsak null - kun utdefinert

### DIFF
--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/saktillos/EventTilDtoMapper.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/saktillos/EventTilDtoMapper.kt
@@ -407,7 +407,8 @@ class EventTilDtoMapper {
             if (åpneAksjonspunkter.isNotEmpty()) {
                 åpneAksjonspunkter
                     .filter { aksjonspunktTilstandDto ->
-                        aksjonspunktTilstandDto.venteårsak != Venteårsak.UDEFINERT
+                        (aksjonspunktTilstandDto.venteårsak != Venteårsak.UDEFINERT &&
+                                aksjonspunktTilstandDto.venteårsak != null)
                             && aksjonspunktTilstandDto.status == AksjonspunktStatus.OPPRETTET
                     }
                     .singleOrNull { aksjonspunktTilstandDto ->


### PR DESCRIPTION
Kafkaconsumer stoppet som følge av exception