### PR TITLE
Trigg oppdatering av tall for kø når reservasjon tas, redusert pause 

### DIFF
--- a/src/main/kotlin/no/nav/k9/los/K9Los.kt
+++ b/src/main/kotlin/no/nav/k9/los/K9Los.kt
@@ -166,6 +166,7 @@ fun Application.k9Los() {
     val oppdaterStatistikkJobb =
         oppdaterStatistikk(
             channel = koin.get<Channel<Boolean>>(named("statistikkRefreshChannel")),
+            configuration = configuration,
             statistikkRepository = koin.get(),
             oppgaveTjeneste = koin.get()
         )

--- a/src/main/kotlin/no/nav/k9/los/KoinProfiles.kt
+++ b/src/main/kotlin/no/nav/k9/los/KoinProfiles.kt
@@ -292,7 +292,8 @@ fun common(app: Application, config: Configuration) = module {
             pepClient = get(),
             azureGraphService = get(),
             statistikkRepository = get(),
-            reservasjonOversetter = get()
+            reservasjonOversetter = get(),
+            statistikkChannel = get(named("statistikkRefreshChannel")),
         )
     }
 
@@ -491,6 +492,7 @@ fun common(app: Application, config: Configuration) = module {
             pepClient = get(),
             pdlService = get(),
             reservasjonV3Repository = get(),
+            statistikkChannel = get(named("statistikkRefreshChannel"))
         )
     }
 

--- a/src/main/kotlin/no/nav/k9/los/eventhandler/OppdaterStatistikk.kt
+++ b/src/main/kotlin/no/nav/k9/los/eventhandler/OppdaterStatistikk.kt
@@ -22,11 +22,12 @@ fun CoroutineScope.oppdaterStatistikk(
 ) = launch(Executors.newSingleThreadExecutor().asCoroutineDispatcher()) {
     try {
         for (skalOppdatereStatistikk in channel) {
-            delay(60_000)
+            delay(500)
             ChannelMetrikker.timeSuspended("oppdaterStatistikk") {
                 DetaljerMetrikker.timeSuspended("oppdaterStatistikk","refreshAntallForAlleKøer",{ oppgaveTjeneste.refreshAntallForAlleKøer() })
                 DetaljerMetrikker.timeSuspended("oppdaterStatistikk", "siste8uker") { statistikkRepository.hentFerdigstilteOgNyeHistorikkMedYtelsetypeSiste8Uker(refresh = true) }
             }
+            delay(27_000)
         }
     } catch (e: Exception) {
         log.error("Feil ved oppdatering av statistikk", e)

--- a/src/main/kotlin/no/nav/k9/los/eventhandler/OppdaterStatistikk.kt
+++ b/src/main/kotlin/no/nav/k9/los/eventhandler/OppdaterStatistikk.kt
@@ -5,6 +5,8 @@ import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import no.nav.k9.los.Configuration
+import no.nav.k9.los.KoinProfile
 import no.nav.k9.los.domene.repository.StatistikkRepository
 import no.nav.k9.los.tjenester.saksbehandler.oppgave.OppgaveTjeneste
 import org.slf4j.Logger
@@ -16,6 +18,7 @@ private val log: Logger = LoggerFactory.getLogger("oppdaterStatistikk")
 
 fun CoroutineScope.oppdaterStatistikk(
     channel: ReceiveChannel<Boolean>,
+    configuration: Configuration,
     statistikkRepository: StatistikkRepository,
     oppgaveTjeneste: OppgaveTjeneste
 
@@ -27,7 +30,11 @@ fun CoroutineScope.oppdaterStatistikk(
                 DetaljerMetrikker.timeSuspended("oppdaterStatistikk","refreshAntallForAlleKøer",{ oppgaveTjeneste.refreshAntallForAlleKøer() })
                 DetaljerMetrikker.timeSuspended("oppdaterStatistikk", "siste8uker") { statistikkRepository.hentFerdigstilteOgNyeHistorikkMedYtelsetypeSiste8Uker(refresh = true) }
             }
-            delay(27_000)
+            if (configuration.koinProfile == KoinProfile.PROD) {
+                delay(57_000) //redusert hyppighet i prod for å unngå å bruke for mye ressurser
+            } else {
+                delay(5_000)
+            }
         }
     } catch (e: Exception) {
         log.error("Feil ved oppdatering av statistikk", e)

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/ko/OppgaveKoTjeneste.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/ko/OppgaveKoTjeneste.kt
@@ -1,5 +1,6 @@
 package no.nav.k9.los.nyoppgavestyring.ko
 
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.runBlocking
 import kotliquery.TransactionalSession
 import no.nav.k9.los.domene.lager.oppgave.v2.TransactionalManager
@@ -38,6 +39,7 @@ class OppgaveKoTjeneste(
     private val reservasjonRepository: ReservasjonRepository,
     private val pdlService: IPdlService,
     private val pepClient: IPepClient,
+    private val statistikkChannel: Channel<Boolean>,
 ) {
     private val log = LoggerFactory.getLogger(OppgaveKoTjeneste::class.java)
 
@@ -137,6 +139,7 @@ class OppgaveKoTjeneste(
                     saksbehandlerRepository.leggTilFlereReservasjoner(
                         innloggetBruker.brukerIdent,
                         v1Reservasjoner.map { r -> r.oppgave })
+                    statistikkChannel.send(true)
                 }
                 // V1-greier til og med denne linjen
                 val reservasjon = reservasjonV3Tjeneste.taReservasjon(

--- a/src/main/kotlin/no/nav/k9/los/tjenester/saksbehandler/oppgave/OppgaveTjeneste.kt
+++ b/src/main/kotlin/no/nav/k9/los/tjenester/saksbehandler/oppgave/OppgaveTjeneste.kt
@@ -1,5 +1,6 @@
 package no.nav.k9.los.tjenester.saksbehandler.oppgave
 
+import kotlinx.coroutines.channels.Channel
 import no.nav.k9.kodeverk.behandling.aksjonspunkt.AksjonspunktDefinisjon
 import no.nav.k9.los.Configuration
 import no.nav.k9.los.KoinProfile
@@ -50,6 +51,7 @@ class OppgaveTjeneste constructor(
     private val pepClient: IPepClient,
     private val statistikkRepository: StatistikkRepository,
     private val reservasjonOversetter: ReservasjonOversetter,
+    private val statistikkChannel: Channel<Boolean>,
 ) {
 
     suspend fun hentOppgaver(oppgavekøId: UUID): List<Oppgave> {
@@ -176,6 +178,7 @@ class OppgaveTjeneste constructor(
                 reservasjonRepository
             )
         }
+        statistikkChannel.send(true)
 
         val saksbehandler = saksbehandlerRepository.finnSaksbehandlerMedIdent(reserveresAvIdent)
         return OppgaveStatusDto(
@@ -1074,6 +1077,8 @@ class OppgaveTjeneste constructor(
                 )
             }
         }
+
+        statistikkChannel.send(true)
 
         DetaljerMetrikker.observe(starttid, "faaOppgaveFraKo", rekusjon)
 

--- a/src/test/kotlin/no/nav/k9/los/KoinModules.kt
+++ b/src/test/kotlin/no/nav/k9/los/KoinModules.kt
@@ -202,7 +202,8 @@ fun buildAndTestConfig(dataSource: DataSource, pepClient: IPepClient = PepClient
             azureGraphService = get(),
             pepClient = get(),
             statistikkRepository = get(),
-            reservasjonOversetter = reservasjonOversetterMock
+            reservasjonOversetter = reservasjonOversetterMock,
+            statistikkChannel = get(named("statistikkRefreshChannel"))
         )
     }
 
@@ -487,6 +488,7 @@ fun buildAndTestConfig(dataSource: DataSource, pepClient: IPepClient = PepClient
             pepClient = get(),
             pdlService = get(),
             reservasjonV3Repository = get(),
+            statistikkChannel = get(named("statistikkRefreshChannel"))
         )
     }
 

--- a/src/test/kotlin/no/nav/k9/los/aksjonspunktbehandling/BeslutterSkalIkkePlukkeEgenSakTest.kt
+++ b/src/test/kotlin/no/nav/k9/los/aksjonspunktbehandling/BeslutterSkalIkkePlukkeEgenSakTest.kt
@@ -24,6 +24,7 @@ import no.nav.k9.los.nyoppgavestyring.domeneadaptere.k9.reservasjonkonvertering.
 import no.nav.k9.los.nyoppgavestyring.reservasjon.ReservasjonV3
 import no.nav.k9.los.tjenester.saksbehandler.oppgave.OppgaveTjeneste
 import org.junit.jupiter.api.Test
+import org.koin.core.qualifier.named
 import org.koin.test.get
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -141,6 +142,7 @@ class BeslutterSkalIkkePlukkeEgenSakTest : AbstractK9LosIntegrationTest() {
             get<IPepClient>(),
             get<StatistikkRepository>(),
             oversetterMock,
+            get(named("statistikkRefreshChannel"))
         )
     }
 }

--- a/src/test/kotlin/no/nav/k9/los/tjenester/saksbehandler/oppgave/OppgaveTjenesteSettSkjermetTest.kt
+++ b/src/test/kotlin/no/nav/k9/los/tjenester/saksbehandler/oppgave/OppgaveTjenesteSettSkjermetTest.kt
@@ -5,7 +5,10 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.runBlocking
-import no.nav.k9.los.*
+import no.nav.k9.los.AbstractPostgresTest
+import no.nav.k9.los.Configuration
+import no.nav.k9.los.KoinProfile
+import no.nav.k9.los.buildAndTestConfig
 import no.nav.k9.los.domene.lager.oppgave.Oppgave
 import no.nav.k9.los.domene.lager.oppgave.v2.OppgaveRepositoryV2
 import no.nav.k9.los.domene.lager.oppgave.v2.TransactionalManager
@@ -17,11 +20,7 @@ import no.nav.k9.los.domene.modell.FagsakYtelseType
 import no.nav.k9.los.domene.modell.KøSortering
 import no.nav.k9.los.domene.modell.OppgaveKø
 import no.nav.k9.los.domene.modell.Saksbehandler
-import no.nav.k9.los.domene.repository.OppgaveKøRepository
-import no.nav.k9.los.domene.repository.OppgaveRepository
-import no.nav.k9.los.domene.repository.ReservasjonRepository
-import no.nav.k9.los.domene.repository.SaksbehandlerRepository
-import no.nav.k9.los.domene.repository.StatistikkRepository
+import no.nav.k9.los.domene.repository.*
 import no.nav.k9.los.integrasjon.abac.IPepClient
 import no.nav.k9.los.integrasjon.abac.PepClientLocal
 import no.nav.k9.los.integrasjon.azuregraph.AzureGraphService
@@ -73,6 +72,7 @@ class OppgaveTjenesteSettSkjermetTest : KoinTest, AbstractPostgresTest() {
         val oppgaveKøOppdatert = Channel<UUID>(1)
         val oppgaveRefreshOppdatert = Channel<UUID>(100)
         val refreshKlienter = Channel<SseEvent>(1000)
+        val statistikkChannel = Channel<Boolean>(Channel.CONFLATED)
 
         val oppgaveRepository = get<OppgaveRepository>()
         val oppgaveRepositoryV2 = get<OppgaveRepositoryV2>()
@@ -110,7 +110,7 @@ class OppgaveTjenesteSettSkjermetTest : KoinTest, AbstractPostgresTest() {
             oppgaveKøRepository,
             saksbehandlerRepository,
             pdlService,
-            reservasjonRepository, config, azureGraphService, pepClient, statistikkRepository, reservasjonOversetter
+            reservasjonRepository, config, azureGraphService, pepClient, statistikkRepository, reservasjonOversetter, statistikkChannel
         )
 
         val uuid = UUID.randomUUID()
@@ -212,6 +212,7 @@ class OppgaveTjenesteSettSkjermetTest : KoinTest, AbstractPostgresTest() {
         val oppgaveKøOppdatert = Channel<UUID>(1)
         val refreshKlienter = Channel<SseEvent>(1000)
         val oppgaverRefresh = Channel<UUID>(1000)
+        val statistikkChannel = Channel<Boolean>(Channel.CONFLATED)
 
         val oppgaveRepository = OppgaveRepository(dataSource = dataSource,pepClient = PepClientLocal(), refreshOppgave = oppgaverRefresh)
         val oppgaveRepositoryV2 = OppgaveRepositoryV2(dataSource = dataSource)
@@ -247,7 +248,7 @@ class OppgaveTjenesteSettSkjermetTest : KoinTest, AbstractPostgresTest() {
             oppgaveKøRepository,
             saksbehandlerRepository,
             pdlService,
-            reservasjonRepository, config, azureGraphService, pepClient, statistikkRepository, reservasjonOversetter
+            reservasjonRepository, config, azureGraphService, pepClient, statistikkRepository, reservasjonOversetter, statistikkChannel
         )
 
         val oppgave1 = Oppgave(
@@ -408,6 +409,7 @@ class OppgaveTjenesteSettSkjermetTest : KoinTest, AbstractPostgresTest() {
         val refreshKlienter = Channel<SseEvent>(1000)
 
         val oppgaverRefresh = Channel<UUID>(1000)
+        val statistikkChannel = Channel<Boolean>(Channel.CONFLATED)
 
         val oppgaveRepository = OppgaveRepository(dataSource = dataSource,pepClient = PepClientLocal(), refreshOppgave = oppgaverRefresh)
         val oppgaveRepositoryV2 = OppgaveRepositoryV2(dataSource = dataSource)
@@ -446,7 +448,7 @@ class OppgaveTjenesteSettSkjermetTest : KoinTest, AbstractPostgresTest() {
             oppgaveKøRepository,
             saksbehandlerRepository,
             pdlService,
-            reservasjonRepository, config, azureGraphService, pepClient, statistikkRepository, reservasjonOversetter
+            reservasjonRepository, config, azureGraphService, pepClient, statistikkRepository, reservasjonOversetter, statistikkChannel
         )
 
 

--- a/src/test/kotlin/no/nav/k9/los/tjenester/saksbehandler/oppgave/OppgaveTjenesteTest.kt
+++ b/src/test/kotlin/no/nav/k9/los/tjenester/saksbehandler/oppgave/OppgaveTjenesteTest.kt
@@ -26,6 +26,7 @@ import no.nav.k9.los.nyoppgavestyring.visningoguttrekk.OppgaveNøkkelDto
 import no.nav.k9.los.tjenester.avdelingsleder.oppgaveko.AndreKriterierDto
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.koin.core.qualifier.named
 import org.koin.test.get
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -932,6 +933,7 @@ class OppgaveTjenesteTest : AbstractK9LosIntegrationTest() {
             get<IPepClient>(),
             get<StatistikkRepository>(),
             oversetterMock,
+            statistikkChannel = get(named("statistikkRefreshChannel")),
         )
     }
 


### PR DESCRIPTION
Pause reduesert fra 60 s til 5s i test
Redusert ventetid første gang til 500ms (som orginalt) for å tilby varm cache raskere ved oppstart