### PR TITLE
Ny standardkø med ytelsestype og liggerHosBeslutter

### DIFF
--- a/src/main/resources/los/standard-ko.json
+++ b/src/main/resources/los/standard-ko.json
@@ -26,6 +26,20 @@
       "verdi": [
         "NEI"
       ]
+    },
+    {
+      "type": "feltverdi",
+      "område": "K9",
+      "kode": "ytelsestype",
+      "operator": "IN",
+      "verdi": []
+    },
+    {
+      "type": "feltverdi",
+      "område": "K9",
+      "kode": "liggerHosBeslutter",
+      "operator": "IN",
+      "verdi": []
     }
   ],
   "select": [],


### PR DESCRIPTION
Ikke påkrevd i frontend og ingen preutfylte verdier. Legges på for convenience da de brukes i de fleste køer, men avdelingsleder kan slette hvis ønskelig