### PR TITLE
Tsff 799/kriterier som skal vaere avanserte valg

### DIFF
--- a/src/main/kotlin/no/nav/k9/los/domene/repository/SaksbehandlerRepository.kt
+++ b/src/main/kotlin/no/nav/k9/los/domene/repository/SaksbehandlerRepository.kt
@@ -360,7 +360,6 @@ class SaksbehandlerRepository(
     suspend fun hentAlleSaksbehandlere(): List<Saksbehandler> {
         Databasekall.map.computeIfAbsent(object {}.javaClass.name + object {}.javaClass.enclosingMethod.name) { LongAdder() }
             .increment()
-        pepClient.kanLeggeUtDriftsmelding()
         val skjermet = pepClient.harTilgangTilKode6()
         val identer = using(sessionOf(dataSource)) {
             it.run(


### PR DESCRIPTION
Felter med `kokriterie: false` vises kun hvis man velger avanserte valg når man skal legge til et nytt køkriterie i frontend