### PR TITLE
Bruker cache for antall oppgaver på v3-køer

### DIFF
--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/ko/OppgaveKoTjeneste.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/ko/OppgaveKoTjeneste.kt
@@ -127,7 +127,8 @@ class OppgaveKoTjeneste(
         skjermet: Boolean
     ): Long {
         val ko = oppgaveKoRepository.hent(oppgaveKoId, skjermet)
-        return antallOppgaverCache.hent(AntallOppgaverForKøCacheKey(oppgaveKoId, filtrerReserverte), antallOppgaverCacheVarighet) { oppgaveQueryService.queryForAntall(QueryRequest(ko.oppgaveQuery, fjernReserverte = filtrerReserverte))}
+        return antallOppgaverCache.hent(AntallOppgaverForKøCacheKey(oppgaveKoId, filtrerReserverte), antallOppgaverCacheVarighet)
+                { oppgaveQueryService.queryForAntall(QueryRequest(ko.oppgaveQuery, fjernReserverte = filtrerReserverte))}
     }
 
     @WithSpan
@@ -135,7 +136,8 @@ class OppgaveKoTjeneste(
         oppgaveKoId: Long
     ): Long {
         val ko = oppgaveKoRepository.hent(oppgaveKoId, runBlocking { pepClient.harTilgangTilKode6() })
-        return antallOppgaverCache.hent(AntallOppgaverForKøCacheKey(oppgaveKoId, true), antallOppgaverCacheVarighet) { oppgaveQueryService.queryForAntall(QueryRequest(ko.oppgaveQuery, fjernReserverte = true))}
+        return antallOppgaverCache.hent(AntallOppgaverForKøCacheKey(oppgaveKoId, true), antallOppgaverCacheVarighet)
+                { oppgaveQueryService.queryForAntall(QueryRequest(ko.oppgaveQuery, fjernReserverte = true))}
     }
 
     @WithSpan

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/ko/OppgaveKoTjeneste.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/ko/OppgaveKoTjeneste.kt
@@ -293,6 +293,10 @@ class OppgaveKoTjeneste(
         return kø
     }
 
+    fun clearCache(){
+        antallOppgaverCache.clear()
+    }
+
     data class AntallOppgaverForKøCacheKey (val oppgaveKoId : Long, val filtrerReserverte: Boolean)
 
     class AntallOppgaverForKøCache : Cache<AntallOppgaverForKøCacheKey, Long>(cacheSizeLimit = null) {

--- a/src/main/kotlin/no/nav/k9/los/utils/Cache.kt
+++ b/src/main/kotlin/no/nav/k9/los/utils/Cache.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 
 open class Cache<K, V>(val cacheSizeLimit: Int?) {
 
-    private val readWriteLock = ReentrantReadWriteLock()
+    private val readWriteLock = ReentrantReadWriteLock(true)
 
     private val keyValueMap = object : LinkedHashMap<K, CacheObject<V>>() {
         override fun removeEldestEntry(eldest: MutableMap.MutableEntry<K, CacheObject<V>>): Boolean {
@@ -68,7 +68,7 @@ open class Cache<K, V>(val cacheSizeLimit: Int?) {
     fun hent(nøkkel: K, duration: Duration, populerCache: () -> V): V {
         get(nøkkel)?.let { return it.value }
 
-        //egen lås pr nøkkel for å kunne oppdatere for flere nøkler samtidig, og unngå at flere tråder forsøker å kjøre unødvendige kall for samme nøkkel
+        //egen lås pr nøkkel for å kunne oppdatere for flere nøkler samtidig, og samtidig unngå at flere tråder forsøker å kjøre unødvendige kall for samme nøkkel
         val låsForHenting = finnLåsForHenting(nøkkel)
         låsForHenting.lock()
         try {

--- a/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/k9saktillos/k9saktillosadapter/K9SakTilLosIT.kt
+++ b/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/k9saktillos/k9saktillosadapter/K9SakTilLosIT.kt
@@ -363,6 +363,7 @@ class K9SakTilLosIT : AbstractK9LosIntegrationTest() {
 
 
     private fun assertAntallIKø(kø: OppgaveKo, forventetAntall: Int) {
+        oppgaveKøTjeneste.clearCache()
         val antallIKøEtterRes = oppgaveKøTjeneste.hentAntallUreserverteOppgaveForKø(kø.id)
         assertThat(antallIKøEtterRes).isEqualTo(forventetAntall.toLong())
     }


### PR DESCRIPTION
Inkluderer invalidation når køen endres, og når det reserveres fra køen.

Justeringer på låsing i Cache for å
1. unngå deadlock
2. unngå å kjøre funksjon som henter verdi for en nøkkel på nytt dersom en annen tråd allerede har gjort det