### PR TITLE
Eksponere informasjon om saksbehandler er lagt inn av avdelignsleder i saksbehandlertabell

### DIFF
--- a/src/main/kotlin/no/nav/k9/los/tjenester/saksbehandler/InnloggetNavAnsattDto.kt
+++ b/src/main/kotlin/no/nav/k9/los/tjenester/saksbehandler/InnloggetNavAnsattDto.kt
@@ -7,5 +7,6 @@ data class InnloggetNavAnsattDto(
     val kanSaksbehandle: Boolean,
     val kanOppgavestyre: Boolean,
     val kanReservere: Boolean,
-    val kanDrifte: Boolean
+    val kanDrifte: Boolean,
+    val finnesISaksbehandlerTabell: Boolean
 )

--- a/src/main/kotlin/no/nav/k9/los/tjenester/saksbehandler/NavAnsattApi.kt
+++ b/src/main/kotlin/no/nav/k9/los/tjenester/saksbehandler/NavAnsattApi.kt
@@ -24,6 +24,8 @@ internal fun Route.NavAnsattApis() {
             requestContextService.withRequestContext(call) {
                 val token = call.idToken()
                 val saksbehandlerIdent = azureGraphService.hentIdentTilInnloggetBruker()
+                val finnesISaksbehandlerTabell =
+                    saksbehandlerRepository.finnSaksbehandlerMedEpost(token.getUsername()) != null
                 val innloggetNavAnsattDto = InnloggetNavAnsattDto(
                     token.getUsername(),
                     token.getName(),
@@ -31,9 +33,11 @@ internal fun Route.NavAnsattApis() {
                     kanSaksbehandle = pepClient.harBasisTilgang(), //TODO mismatch mellom navnet 'kanSaksbehandle' og at alle som har tilgang til systemet har basistilgang
                     kanOppgavestyre = pepClient.erOppgaveStyrer(),
                     kanReservere = pepClient.harTilgangTilReserveringAvOppgaver(),
-                    kanDrifte = pepClient.kanLeggeUtDriftsmelding()
+                    kanDrifte = pepClient.kanLeggeUtDriftsmelding(),
+                    finnesISaksbehandlerTabell = finnesISaksbehandlerTabell
                 )
-                if (saksbehandlerRepository.finnSaksbehandlerMedEpost(token.getUsername()) != null) {
+                if (finnesISaksbehandlerTabell) {
+                    //  oppdaterer saksbehandler i tabell etter at epost er lagt inn av avdelingsleder
                     saksbehandlerRepository.addSaksbehandler(
                         Saksbehandler(
                             id = null,
@@ -58,7 +62,8 @@ internal fun Route.NavAnsattApis() {
                     kanSaksbehandle = true,
                     kanOppgavestyre = true,
                     kanReservere = true,
-                    kanDrifte = true
+                    kanDrifte = true,
+                    finnesISaksbehandlerTabell = true
                 )
             )
         }


### PR DESCRIPTION
For at saksbehandler skal kunne ha reservasjoner eller legges på oppgavekøer i LOS må de legges inn av avdelingsleder i saksbehandlertabellen.

Frontend må vite om de er lagt inn for å tilpasse visning til bl.a veiledere