### PR TITLE
Ikke 404 på få-oppgave-endepunkt

### DIFF
--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/ko/OppgaveKoApis.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/ko/OppgaveKoApis.kt
@@ -196,17 +196,23 @@ fun Route.OppgaveKoApis() {
                 val innloggetBruker = saksbehandlerRepository.finnSaksbehandlerMedEpost(
                     kotlin.coroutines.coroutineContext.idToken().getUsername()
                 )!!
-                val (reservertOppgave, reservasjonFraKø) = oppgaveKoTjeneste.taReservasjonFraKø(
+                val oppgaveMuligReservert = oppgaveKoTjeneste.taReservasjonFraKø(
                     innloggetBrukerId = innloggetBruker.id!!,
                     oppgaveKoId = oppgavekøId.toLong(),
                     kotlin.coroutines.coroutineContext
-                ) ?: Pair(null, null)
-
-                if (reservasjonFraKø != null) {
-                    call.respond(ReservasjonV3FraKøDto(reservasjonFraKø, reservertOppgave!!, innloggetBruker))
-                } else {
-                    call.respond(HttpStatusCode.NotFound, "Fant ingen oppgave i valgt kø")
-                }
+                )
+                call.respond(
+                    when (oppgaveMuligReservert) {
+                        is OppgaveMuligReservert.Reservert -> listOf(
+                            ReservasjonV3FraKøDto(
+                                oppgaveMuligReservert.reservasjon,
+                                oppgaveMuligReservert.oppgave,
+                                innloggetBruker
+                            )
+                        )
+                        OppgaveMuligReservert.IkkeReservert -> emptyList()
+                    }
+                )
             } else {
                 call.respond(HttpStatusCode.Forbidden, "Innlogget bruker mangler tilgang til å reservere oppgaver")
             }

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/ko/OppgaveMuligReservert.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/ko/OppgaveMuligReservert.kt
@@ -1,0 +1,9 @@
+package no.nav.k9.los.nyoppgavestyring.ko
+
+import no.nav.k9.los.nyoppgavestyring.reservasjon.ReservasjonV3
+import no.nav.k9.los.nyoppgavestyring.visningoguttrekk.Oppgave
+
+sealed class OppgaveMuligReservert {
+    data class Reservert(val oppgave: Oppgave, val reservasjon: ReservasjonV3) : OppgaveMuligReservert()
+    data object IkkeReservert : OppgaveMuligReservert()
+}

--- a/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/k9saktillos/k9saktillosadapter/K9SakTilLosIT.kt
+++ b/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/k9saktillos/k9saktillosadapter/K9SakTilLosIT.kt
@@ -21,6 +21,7 @@ import no.nav.k9.los.nyoppgavestyring.FeltType
 import no.nav.k9.los.nyoppgavestyring.OppgaveTestDataBuilder
 import no.nav.k9.los.nyoppgavestyring.domeneadaptere.k9.saktillos.K9SakTilLosHistorikkvaskTjeneste
 import no.nav.k9.los.nyoppgavestyring.ko.OppgaveKoTjeneste
+import no.nav.k9.los.nyoppgavestyring.ko.OppgaveMuligReservert
 import no.nav.k9.los.nyoppgavestyring.ko.db.OppgaveKoRepository
 import no.nav.k9.los.nyoppgavestyring.ko.dto.OppgaveKo
 import no.nav.k9.los.nyoppgavestyring.mottak.oppgave.Oppgavestatus
@@ -29,8 +30,6 @@ import no.nav.k9.los.nyoppgavestyring.query.QueryRequest
 import no.nav.k9.los.nyoppgavestyring.query.dto.query.FeltverdiOppgavefilter
 import no.nav.k9.los.nyoppgavestyring.query.dto.query.OppgaveQuery
 import no.nav.k9.los.nyoppgavestyring.query.mapping.FeltverdiOperator
-import no.nav.k9.los.nyoppgavestyring.reservasjon.ReservasjonV3
-import no.nav.k9.los.nyoppgavestyring.visningoguttrekk.Oppgave
 import no.nav.k9.los.nyoppgavestyring.visningoguttrekk.OppgaveNøkkelDto
 import no.nav.k9.los.tjenester.saksbehandler.IIdToken
 import no.nav.k9.los.tjenester.saksbehandler.oppgave.OppgaveApisTjeneste
@@ -159,7 +158,7 @@ class K9SakTilLosIT : AbstractK9LosIntegrationTest() {
             kø.id,
             CoroutineRequestContext(mockk<IIdToken>(relaxed = true))
         )
-        assertThat(resultat).isNull()
+        assertThat(resultat is OppgaveMuligReservert.IkkeReservert).isTrue()
     }
 
     @Test
@@ -183,7 +182,7 @@ class K9SakTilLosIT : AbstractK9LosIntegrationTest() {
         assertThat(antallIKø).isEqualTo(1)
 
         val resultat = taReservasjonFra(kø, TestSaksbehandler.SARA)
-        assertThat(resultat).isNotNull()
+        assertThat(resultat is OppgaveMuligReservert.Reservert).isTrue()
 
         val skjermet1 = runBlocking { pepClient.harTilgangTilKode6() }
         val filtrerReserverte1 = true
@@ -418,7 +417,7 @@ class K9SakTilLosIT : AbstractK9LosIntegrationTest() {
         assertThat(antallIKøEtterRes).isEqualTo(forventetAntall.toLong())
     }
 
-    private fun taReservasjonFra(kø: OppgaveKo, saksbehandler: Saksbehandler): Pair<Oppgave, ReservasjonV3>? {
+    private fun taReservasjonFra(kø: OppgaveKo, saksbehandler: Saksbehandler): OppgaveMuligReservert {
         return oppgaveKøTjeneste.taReservasjonFraKø(
             saksbehandler.id!!,
             kø.id,


### PR DESCRIPTION
Endepunkt returnerer nå liste i stedet for enkeltverdi eller 404. Gjør denne endringen fordi 404 gir logging av feil i frontend. Alternativt kunne vi respondert med 400 og en feilbeskrivelse.

Bruker sealed class `OppgaveMuligReservert`, med alternativene `Reservert` og `IkkeReservert`, i stedet for `Pair<Oppgave, ReservasjonV3>?`. Endepunkt kunne nok også returnert sealed class med typeinformasjon i stedet for array, da må vi i så fall bestemme oss for konvensjon for Jackson-konfigurering.