### PR TITLE
Bruke ktor-client i stedet for fuel

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,13 +48,11 @@ dependencies {
     implementation("io.ktor:ktor-server-cors:$ktorVersion")
     implementation("io.ktor:ktor-server-call-logging:$ktorVersion")
     implementation("io.ktor:ktor-server-html-builder-jvm:$ktorVersion")
-    implementation("io.ktor:ktor-server-websockets-jvm:$ktorVersion")
-    implementation("io.ktor:ktor-client-auth-jvm:$ktorVersion")
 
     // Client
-    implementation("no.nav.helse:dusseldorf-ktor-client:$dusseldorfKtorVersion")
+    implementation("io.ktor:ktor-client-core:$ktorVersion")
+    implementation("io.ktor:ktor-client-java:$ktorVersion")
     implementation("no.nav.helse:dusseldorf-oauth2-client:$dusseldorfKtorVersion")
-    implementation("org.apache.httpcomponents:httpclient:4.5.14")
 
     // Kafka
     implementation("org.apache.kafka:kafka-streams:$kafkaVersion") {
@@ -67,9 +65,6 @@ dependencies {
     }
 
     // Tilgangskontroll
-    implementation("no.nav.common:auth:$navTilgangskontroll")
-    implementation("no.nav.common:rest:$navTilgangskontroll")
-    implementation("com.google.code.gson:gson:2.11.0")
     implementation("no.nav.sif.abac:kontrakt:1.4.0")
 
     // Kontrakter
@@ -105,12 +100,8 @@ dependencies {
     testImplementation("io.ktor:ktor-server-test-host-jvm:$ktorVersion") {
         exclude(group = "org.eclipse.jetty")
     }
-    testImplementation("org.skyscreamer:jsonassert:$jsonassertVersion")
-
     testImplementation("org.testcontainers:postgresql:$testContainers")
     testImplementation("io.insert-koin:koin-test-junit5:$koinVersion")
-
-    testImplementation("org.apache.commons:commons-compress:1.27.1")
 }
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,6 @@ val koinVersion = "4.0.2"
 val kotliqueryVersion = "1.9.1"
 val k9SakVersion = "5.4.16"
 val k9KlageVersion = "0.4.7"
-val fuelVersion = "2.3.1"
 val jacksonVersion = "2.17.2"
 val commonsTextVersion = "1.13.0"
 
@@ -89,11 +88,6 @@ dependencies {
     implementation(enforcedPlatform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
     implementation("org.apache.commons:commons-text:$commonsTextVersion")
     implementation("com.papertrailapp:logback-syslog4j:1.0.0")
-    implementation("com.github.kittinunf.fuel:fuel:$fuelVersion")
-    implementation("com.github.kittinunf.fuel:fuel-coroutines:$fuelVersion") {
-        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
-    }
-
     implementation("io.github.smiley4:ktor-swagger-ui:3.6.1")
 
 

--- a/nais/naiserator.yaml
+++ b/nais/naiserator.yaml
@@ -49,7 +49,6 @@ spec:
         kvPath: {{serviceuser_kvpath}}
       - mountPath: /var/run/secrets/nais.io/vault
         kvPath: {{vault_kvpath}}
-  webproxy: true
   kafka:
     pool: {{kafka_pool}}
     streams: true

--- a/src/main/kotlin/no/nav/k9/los/K9Los.kt
+++ b/src/main/kotlin/no/nav/k9/los/K9Los.kt
@@ -108,7 +108,7 @@ fun Application.k9Los() {
     val issuers = configuration.issuers()
 
     install(Koin) {
-        modules(selectModuleBasedOnProfile(this@k9Los, config = configuration))
+        modules(selectModulesBasedOnProfile(this@k9Los, config = configuration))
     }
 
     val koin = getKoin()

--- a/src/main/kotlin/no/nav/k9/los/KoinProfiles.kt
+++ b/src/main/kotlin/no/nav/k9/los/KoinProfiles.kt
@@ -1,5 +1,6 @@
 package no.nav.k9.los
 
+import io.ktor.client.*
 import io.ktor.server.application.*
 import kotlinx.coroutines.channels.Channel
 import no.nav.helse.dusseldorf.ktor.health.HealthService
@@ -781,9 +782,12 @@ fun localDevConfig() = module {
 }
 
 fun preprodConfig(config: Configuration) = module {
+    single<HttpClient> { HttpClient() }
+    
     single<IAzureGraphService> {
         AzureGraphService(
-            accessTokenClient = get<AccessTokenClientResolver>().azureV2()
+            accessTokenClient = get<AccessTokenClientResolver>().azureV2(),
+            httpClient = get<HttpClient>()
         )
     }
     single<IK9SakService> {
@@ -791,7 +795,8 @@ fun preprodConfig(config: Configuration) = module {
             configuration = get(),
             accessTokenClient = get<AccessTokenClientResolver>().azureV2(),
             scope = "api://dev-fss.k9saksbehandling.k9-sak/.default",
-            k9SakBehandlingOppfrisketRepository = get()
+            k9SakBehandlingOppfrisketRepository = get(),
+            httpClient = get<HttpClient>()
         )
     }
 
@@ -802,7 +807,8 @@ fun preprodConfig(config: Configuration) = module {
             baseUrl = config.pdlUrl(),
             accessTokenClient = get<AccessTokenClientResolver>().azureV2(),
             scope = "api://dev-fss.pdl.pdl-api/.default",
-            azureGraphService = get<IAzureGraphService>()
+            azureGraphService = get<IAzureGraphService>(),
+            httpClient = get<HttpClient>()
         )
     }
 
@@ -810,7 +816,8 @@ fun preprodConfig(config: Configuration) = module {
         K9SakBerikerSystemKlient(
             configuration = get(),
             accessTokenClient = get<AccessTokenClientResolver>().azureV2(),
-            scope = "api://dev-fss.k9saksbehandling.k9-sak/.default"
+            scope = "api://dev-fss.k9saksbehandling.k9-sak/.default",
+            httpClient = get<HttpClient>()
         )
     }
 
@@ -819,7 +826,8 @@ fun preprodConfig(config: Configuration) = module {
             configuration = get(),
             accessTokenClient = get<AccessTokenClientResolver>().azureV2(),
             scopeKlage = "api://dev-fss.k9saksbehandling.k9-klage/.default",
-            scopeSak = "api://dev-fss.k9saksbehandling.k9-sak/.default"
+            scopeSak = "api://dev-fss.k9saksbehandling.k9-sak/.default",
+            httpClient = get<HttpClient>()
         )
     }
 
@@ -828,6 +836,7 @@ fun preprodConfig(config: Configuration) = module {
             configuration = get(),
             accessTokenClient = get<AccessTokenClientResolver>().azureV2(),
             scope = "api://dev-fss.k9saksbehandling.sif-abac-pdp/.default",
+            httpClient = get()
         )
     }
     single<IPepClient> {
@@ -836,9 +845,12 @@ fun preprodConfig(config: Configuration) = module {
 }
 
 fun prodConfig(config: Configuration) = module {
+    single<HttpClient> { HttpClient() }
+    
     single<IAzureGraphService> {
         AzureGraphService(
-            accessTokenClient = get<AccessTokenClientResolver>().azureV2()
+            accessTokenClient = get<AccessTokenClientResolver>().azureV2(),
+            httpClient = get()
         )
     }
     single<IK9SakService> {
@@ -846,7 +858,8 @@ fun prodConfig(config: Configuration) = module {
             configuration = get(),
             accessTokenClient = get<AccessTokenClientResolver>().azureV2(),
             scope = "api://prod-fss.k9saksbehandling.k9-sak/.default",
-            k9SakBehandlingOppfrisketRepository = get()
+            k9SakBehandlingOppfrisketRepository = get(),
+            httpClient = get()
         )
     }
 
@@ -857,7 +870,8 @@ fun prodConfig(config: Configuration) = module {
             baseUrl = config.pdlUrl(),
             accessTokenClient = get<AccessTokenClientResolver>().azureV2(),
             scope = "api://prod-fss.pdl.pdl-api/.default",
-            azureGraphService = get<IAzureGraphService>()
+            azureGraphService = get<IAzureGraphService>(),
+            httpClient = get()
         )
     }
 
@@ -865,7 +879,8 @@ fun prodConfig(config: Configuration) = module {
         K9SakBerikerSystemKlient(
             configuration = get(),
             accessTokenClient = get<AccessTokenClientResolver>().azureV2(),
-            scope = "api://prod-fss.k9saksbehandling.k9-sak/.default"
+            scope = "api://prod-fss.k9saksbehandling.k9-sak/.default",
+            httpClient = get()
         )
     }
 
@@ -874,7 +889,8 @@ fun prodConfig(config: Configuration) = module {
             configuration = get(),
             accessTokenClient = get<AccessTokenClientResolver>().azureV2(),
             scopeKlage = "api://prod-fss.k9saksbehandling.k9-klage/.default",
-            scopeSak = "api://prod-fss.k9saksbehandling.k9-sak/.default"
+            scopeSak = "api://prod-fss.k9saksbehandling.k9-sak/.default",
+            httpClient = get()
         )
     }
 
@@ -883,6 +899,7 @@ fun prodConfig(config: Configuration) = module {
             configuration = get(),
             accessTokenClient = get<AccessTokenClientResolver>().azureV2(),
             scope = "api://prod-fss.k9saksbehandling.sif-abac-pdp/.default",
+            httpClient = get()
         )
     }
 

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/eventtiloppgave/saktillos/beriker/K9SakBerikerSystemKlient.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/eventtiloppgave/saktillos/beriker/K9SakBerikerSystemKlient.kt
@@ -1,8 +1,9 @@
 package no.nav.k9.los.nyoppgavestyring.domeneadaptere.k9.eventtiloppgave.saktillos.beriker
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import com.github.kittinunf.fuel.coroutines.awaitStringResponseResult
-import com.github.kittinunf.fuel.httpGet
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import kotlinx.coroutines.runBlocking
@@ -15,16 +16,18 @@ import no.nav.k9.los.nyoppgavestyring.domeneadaptere.k9.eventtiloppgave.Transien
 import no.nav.k9.los.nyoppgavestyring.infrastruktur.rest.NavHeaders
 import no.nav.k9.los.nyoppgavestyring.infrastruktur.utils.LosObjectMapper
 import no.nav.k9.sak.kontrakt.produksjonsstyring.los.BehandlingMedFagsakDto
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.util.*
 
 class K9SakBerikerSystemKlient(
     private val configuration: Configuration,
-    private val accessTokenClient: AccessTokenClient,
-    scope: String
+    accessTokenClient: AccessTokenClient,
+    scope: String,
+    private val httpClient: HttpClient
 ) : K9SakBerikerInterfaceKludge {
-    val log = LoggerFactory.getLogger("K9SakAdapter")
+    val log: Logger = LoggerFactory.getLogger("K9SakAdapter")
     private val cachedAccessTokenClient = CachedAccessTokenClient(accessTokenClient)
     private val url = configuration.k9Url()
     private val scopes = setOf(scope)
@@ -35,55 +38,53 @@ class K9SakBerikerSystemKlient(
     }
 
     private suspend fun hent(behandlingUUID: UUID, antallForsøk: Int = 3): BehandlingMedFagsakDto? {
-        val parameters = listOf<Pair<String, String>>(Pair("behandlingUuid", behandlingUUID.toString()))
-        val httpRequest = "${url}/los/behandling"
-            .httpGet(parameters)
-            .header(
-                //OBS! Dette kalles bare med system token, og skal ikke brukes ved saksbehandler token
-                HttpHeaders.Authorization to cachedAccessTokenClient.getAccessToken(scopes).asAuthoriationHeader(),
-                HttpHeaders.Accept to "application/json",
-                HttpHeaders.ContentType to "application/json",
-                NavHeaders.CallId to UUID.randomUUID().toString()
-            )
-        val (_, response, result) = Retry.retry(
+        val response = Retry.retry(
             tries = antallForsøk,
             operation = "berik",
             initialDelay = Duration.ofMillis(200),
             factor = 2.0,
             logger = log
-        ) { httpRequest.awaitStringResponseResult() }
+        ) {
+            httpClient.get("${url}/los/behandling") {
+                parameter("behandlingUuid", behandlingUUID.toString())
+                header(
+                    //OBS! Dette kalles bare med system token, og skal ikke brukes ved saksbehandler token
+                    HttpHeaders.Authorization, cachedAccessTokenClient.getAccessToken(scopes).asAuthoriationHeader()
+                )
+                header(HttpHeaders.Accept, "application/json")
+                header(HttpHeaders.ContentType, "application/json")
+                header(NavHeaders.CallId, UUID.randomUUID().toString())
+            }
+        }
 
-        if (response.statusCode == HttpStatusCode.NoContent.value) {
+        if (response.status == HttpStatusCode.NoContent) {
             return null
         }
-        val abc = result.fold(
-            { success ->
-                success
-            },
-            { error ->
-                if (error.response.statusCode == HttpStatusCode.ServiceUnavailable.value
-                    || error.response.statusCode == HttpStatusCode.GatewayTimeout.value
-                    || error.response.statusCode == HttpStatusCode.RequestTimeout.value
-                ) {
-                    throw TransientException("k9sak er ikke tilgjengelig for beriking av k9sak-oppgave, fikk http code ${error.response.statusCode}", error.exception)
-                }
-
-                val feiltekst = error.response.body().asString("text/plain")
-                val ignorerManglendeTilgangPgaUtdatertTestdata = configuration.koinProfile == KoinProfile.PREPROD
-                        && feiltekst.contains("MANGLER_TILGANG_FEIL")
-
-                log.error(
-                    (if (ignorerManglendeTilgangPgaUtdatertTestdata) "IGNORERER I DEV: " else "") +
-                            "Error response = '$feiltekst' fra '${httpRequest.url}'"
-                )
-                log.error(error.toString())
-
-                if (ignorerManglendeTilgangPgaUtdatertTestdata) {
-                    return null
-                } else throw IllegalStateException("Feil ved henting av behandling fra k9-sak", error.exception)
-
+        
+        val abc = if (response.status.isSuccess()) {
+            response.bodyAsText()
+        } else {
+            if (response.status == HttpStatusCode.ServiceUnavailable
+                || response.status == HttpStatusCode.GatewayTimeout
+                || response.status == HttpStatusCode.RequestTimeout
+            ) {
+                throw TransientException("k9sak er ikke tilgjengelig for beriking av k9sak-oppgave, fikk http code ${response.status.value}", Exception("HTTP error ${response.status.value}"))
             }
-        )
+
+            val feiltekst = response.bodyAsText()
+            val ignorerManglendeTilgangPgaUtdatertTestdata = configuration.koinProfile == KoinProfile.PREPROD
+                    && feiltekst.contains("MANGLER_TILGANG_FEIL")
+
+            log.error(
+                (if (ignorerManglendeTilgangPgaUtdatertTestdata) "IGNORERER I DEV: " else "") +
+                        "Error response = '$feiltekst' fra '${response.request.url}'"
+            )
+            log.error("HTTP ${response.status.value} ${response.status.description}")
+
+            if (ignorerManglendeTilgangPgaUtdatertTestdata) {
+                return null
+            } else throw IllegalStateException("Feil ved henting av behandling fra k9-sak")
+        }
 
         return LosObjectMapper.instance.readValue<BehandlingMedFagsakDto>(abc)
     }

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/infrastruktur/abac/SifAbacPdpKlient.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/infrastruktur/abac/SifAbacPdpKlient.kt
@@ -1,8 +1,9 @@
 package no.nav.k9.los.nyoppgavestyring.infrastruktur.abac
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import com.github.kittinunf.fuel.coroutines.awaitStringResponseResult
-import com.github.kittinunf.fuel.httpPost
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import no.nav.helse.dusseldorf.ktor.core.Retry
 import no.nav.helse.dusseldorf.oauth2.client.AccessTokenClient
@@ -27,7 +28,8 @@ import kotlin.coroutines.coroutineContext
 class SifAbacPdpKlient(
     configuration: Configuration,
     accessTokenClient: AccessTokenClient,
-    scope: String
+    scope: String,
+    private val httpClient: HttpClient
 ) : ISifAbacPdpKlient {
     val log: Logger = LoggerFactory.getLogger("SifAbacPdpKlient")
     private val cachedAccessTokenClient = CachedAccessTokenClient(accessTokenClient)
@@ -38,28 +40,30 @@ class SifAbacPdpKlient(
     override suspend fun diskresjonskoderPerson(aktørId: AktørId): Set<Diskresjonskode> {
         val antallForsøk = 3
         val systemToken = cachedAccessTokenClient.getAccessToken(scopes)
-        val httpRequest = "${url}/api/diskresjonskoder/person"
-            .httpPost()
-            .body(LosObjectMapper.instance.writeValueAsString(aktørId))
-            .header(
-                //OBS! Dette kalles bare med system token, og skal ikke brukes ved saksbehandler token
-                HttpHeaders.Authorization to systemToken.asAuthoriationHeader(),
-                HttpHeaders.Accept to "application/json",
-                HttpHeaders.ContentType to "application/json",
-                NavHeaders.CallId to UUID.randomUUID().toString()
-            )
-        val (_, _, result) = Retry.retry(
+        val response = Retry.retry(
             tries = antallForsøk,
             operation = "diskresjonskoder-person",
             initialDelay = Duration.ofMillis(200),
             factor = 2.0,
             logger = log
-        ) { httpRequest.awaitStringResponseResult() }
+        ) {
+            httpClient.post("${url}/api/diskresjonskoder/person") {
+                setBody(LosObjectMapper.instance.writeValueAsString(aktørId))
+                header(
+                    //OBS! Dette kalles bare med system token, og skal ikke brukes ved saksbehandler token
+                    HttpHeaders.Authorization, systemToken.asAuthoriationHeader()
+                )
+                header(HttpHeaders.Accept, "application/json")
+                header(HttpHeaders.ContentType, "application/json")
+                header(NavHeaders.CallId, UUID.randomUUID().toString())
+            }
+        }
 
-        val abc = result.fold(
-            { success -> success },
-            { error -> throw IllegalStateException("Feil ved henting av diskresjonskoder for person fra sif-abac-pdp: $error") }
-        )
+        val abc = if (response.status.isSuccess()) {
+            response.bodyAsText()
+        } else {
+            throw IllegalStateException("Feil ved henting av diskresjonskoder for person fra sif-abac-pdp: HTTP ${response.status.value} ${response.status.description}")
+        }
 
         return LosObjectMapper.instance.readValue<List<Diskresjonskode>>(abc)
             .toSet()
@@ -76,28 +80,30 @@ class SifAbacPdpKlient(
 
         val completeUrl = "${url}/api/diskresjonskoder/k9/sak"
         val body = LosObjectMapper.instance.writeValueAsString(saksnummerDto)
-        val httpRequest = completeUrl
-            .httpPost()
-            .body(body)
-            .header(
-                //OBS! Dette kalles bare med system token, og skal ikke brukes ved saksbehandler token
-                HttpHeaders.Authorization to systemToken.asAuthoriationHeader(),
-                HttpHeaders.Accept to "application/json",
-                HttpHeaders.ContentType to "application/json",
-                NavHeaders.CallId to UUID.randomUUID().toString()
-            )
-        val (_, _, result) = Retry.retry(
+        val response = Retry.retry(
             tries = antallForsøk,
             operation = "diskresjonskoder-sak",
             initialDelay = Duration.ofMillis(200),
             factor = 2.0,
             logger = log
-        ) { httpRequest.awaitStringResponseResult() }
+        ) {
+            httpClient.post(completeUrl) {
+                setBody(body)
+                header(
+                    //OBS! Dette kalles bare med system token, og skal ikke brukes ved saksbehandler token
+                    HttpHeaders.Authorization, systemToken.asAuthoriationHeader()
+                )
+                header(HttpHeaders.Accept, "application/json")
+                header(HttpHeaders.ContentType, "application/json")
+                header(NavHeaders.CallId, UUID.randomUUID().toString())
+            }
+        }
 
-        val abc = result.fold(
-            { success -> success },
-            { error -> throw IllegalStateException("Feil ved henting av diskresjonskoder for sak fra sif-abac-pdp $completeUrl for saksnummer $body : $error") }
-        )
+        val abc = if (response.status.isSuccess()) {
+            response.bodyAsText()
+        } else {
+            throw IllegalStateException("Feil ved henting av diskresjonskoder for sak fra sif-abac-pdp $completeUrl for saksnummer $body : HTTP ${response.status.value} ${response.status.description}")
+        }
 
         return LosObjectMapper.instance.readValue<List<Diskresjonskode>>(abc)
             .toSet()
@@ -108,28 +114,30 @@ class SifAbacPdpKlient(
         val antallForsøk = 3
         val jwt = coroutineContext.idToken().value
         val oboToken = cachedAccessTokenClient.getAccessToken(scopes, jwt)
-        val httpRequest = "${url}/api/tilgangskontroll/v2/k9/sak"
-            .httpPost()
-            .body(LosObjectMapper.instance.writeValueAsString(request))
-            .header(
-                //OBS! Dette kalles bare med obo token
-                HttpHeaders.Authorization to oboToken.asAuthoriationHeader(),
-                HttpHeaders.Accept to "application/json",
-                HttpHeaders.ContentType to "application/json",
-                NavHeaders.CallId to UUID.randomUUID().toString()
-            )
-        val (_, _, result) = Retry.retry(
+        val response = Retry.retry(
             tries = antallForsøk,
             operation = "tilgangskontroll-sak",
             initialDelay = Duration.ofMillis(200),
             factor = 2.0,
             logger = log
-        ) { httpRequest.awaitStringResponseResult() }
+        ) {
+            httpClient.post("${url}/api/tilgangskontroll/v2/k9/sak") {
+                setBody(LosObjectMapper.instance.writeValueAsString(request))
+                header(
+                    //OBS! Dette kalles bare med obo token
+                    HttpHeaders.Authorization, oboToken.asAuthoriationHeader()
+                )
+                header(HttpHeaders.Accept, "application/json")
+                header(HttpHeaders.ContentType, "application/json")
+                header(NavHeaders.CallId, UUID.randomUUID().toString())
+            }
+        }
 
-        val abc = result.fold(
-            { success -> success },
-            { error -> throw IllegalStateException("Feil ved sjekk av tilgang til sak mot sif-abac-pdp: $error") }
-        )
+        val abc = if (response.status.isSuccess()) {
+            response.bodyAsText()
+        } else {
+            throw IllegalStateException("Feil ved sjekk av tilgang til sak mot sif-abac-pdp: HTTP ${response.status.value} ${response.status.description}")
+        }
 
         return LosObjectMapper.instance.readValue<Tilgangsbeslutning>(abc).harTilgang()
     }
@@ -155,27 +163,29 @@ class SifAbacPdpKlient(
         val antallForsøk = 3
         val systemToken = cachedAccessTokenClient.getAccessToken(scopes)
         val body = LosObjectMapper.instance.writeValueAsString(request)
-        val httpRequest = "${url}/api/tilgangskontroll/v2/k9/sak-grupper"
-            .httpPost()
-            .body(body)
-            .header(
-                HttpHeaders.Authorization to systemToken.asAuthoriationHeader(),
-                HttpHeaders.Accept to "application/json",
-                HttpHeaders.ContentType to "application/json",
-                NavHeaders.CallId to UUID.randomUUID().toString()
-            )
-        val (_, _, result) = Retry.retry(
+        val response = Retry.retry(
             tries = antallForsøk,
             operation = "tilgangskontroll-sak-grupper",
             initialDelay = Duration.ofMillis(200),
             factor = 2.0,
             logger = log
-        ) { httpRequest.awaitStringResponseResult() }
+        ) {
+            httpClient.post("${url}/api/tilgangskontroll/v2/k9/sak-grupper") {
+                setBody(body)
+                header(
+                    HttpHeaders.Authorization, systemToken.asAuthoriationHeader()
+                )
+                header(HttpHeaders.Accept, "application/json")
+                header(HttpHeaders.ContentType, "application/json")
+                header(NavHeaders.CallId, UUID.randomUUID().toString())
+            }
+        }
 
-        val abc = result.fold(
-            { success -> success },
-            { error -> throw IllegalStateException("Feil ved sjekk av tilgang til sak vha grupper mot sif-abac-pdp ${if (environment == KoinProfile.PREPROD) body else ""}: $error") }
-        )
+        val abc = if (response.status.isSuccess()) {
+            response.bodyAsText()
+        } else {
+            throw IllegalStateException("Feil ved sjekk av tilgang til sak vha grupper mot sif-abac-pdp ${if (environment == KoinProfile.PREPROD) body else ""}: HTTP ${response.status.value} ${response.status.description}")
+        }
 
         return LosObjectMapper.instance.readValue<Tilgangsbeslutning>(abc).harTilgang()
     }
@@ -185,28 +195,30 @@ class SifAbacPdpKlient(
         val antallForsøk = 3
         val jwt = coroutineContext.idToken().value
         val oboToken = cachedAccessTokenClient.getAccessToken(scopes, jwt)
-        val httpRequest = "${url}/api/tilgangskontroll/v2/k9/personer"
-            .httpPost()
-            .body(LosObjectMapper.instance.writeValueAsString(request))
-            .header(
-                //OBS! Dette kalles bare med obo token
-                HttpHeaders.Authorization to oboToken.asAuthoriationHeader(),
-                HttpHeaders.Accept to "application/json",
-                HttpHeaders.ContentType to "application/json",
-                NavHeaders.CallId to UUID.randomUUID().toString()
-            )
-        val (_, _, result) = Retry.retry(
+        val response = Retry.retry(
             tries = antallForsøk,
             operation = "tilgangskontroll-personer",
             initialDelay = Duration.ofMillis(200),
             factor = 2.0,
             logger = log
-        ) { httpRequest.awaitStringResponseResult() }
+        ) {
+            httpClient.post("${url}/api/tilgangskontroll/v2/k9/personer") {
+                setBody(LosObjectMapper.instance.writeValueAsString(request))
+                header(
+                    //OBS! Dette kalles bare med obo token
+                    HttpHeaders.Authorization, oboToken.asAuthoriationHeader()
+                )
+                header(HttpHeaders.Accept, "application/json")
+                header(HttpHeaders.ContentType, "application/json")
+                header(NavHeaders.CallId, UUID.randomUUID().toString())
+            }
+        }
 
-        val abc = result.fold(
-            { success -> success },
-            { error -> throw IllegalStateException("Feil ved sjekk av tilgang til personer mot sif-abac-pdp: $error") }
-        )
+        val abc = if (response.status.isSuccess()) {
+            response.bodyAsText()
+        } else {
+            throw IllegalStateException("Feil ved sjekk av tilgang til personer mot sif-abac-pdp: HTTP ${response.status.value} ${response.status.description}")
+        }
 
         return LosObjectMapper.instance.readValue<Tilgangsbeslutning>(abc).harTilgang()
     }
@@ -228,27 +240,29 @@ class SifAbacPdpKlient(
         val antallForsøk = 3
         val systemToken = cachedAccessTokenClient.getAccessToken(scopes)
         val body = LosObjectMapper.instance.writeValueAsString(request)
-        val httpRequest = "${url}/api/tilgangskontroll/v2/k9/personer-grupper"
-            .httpPost()
-            .body(body)
-            .header(
-                HttpHeaders.Authorization to systemToken.asAuthoriationHeader(),
-                HttpHeaders.Accept to "application/json",
-                HttpHeaders.ContentType to "application/json",
-                NavHeaders.CallId to UUID.randomUUID().toString()
-            )
-        val (_, _, result) = Retry.retry(
+        val response = Retry.retry(
             tries = antallForsøk,
             operation = "tilgangskontroll-personer-grupper",
             initialDelay = Duration.ofMillis(200),
             factor = 2.0,
             logger = log
-        ) { httpRequest.awaitStringResponseResult() }
+        ) {
+            httpClient.post("${url}/api/tilgangskontroll/v2/k9/personer-grupper") {
+                setBody(body)
+                header(
+                    HttpHeaders.Authorization, systemToken.asAuthoriationHeader()
+                )
+                header(HttpHeaders.Accept, "application/json")
+                header(HttpHeaders.ContentType, "application/json")
+                header(NavHeaders.CallId, UUID.randomUUID().toString())
+            }
+        }
 
-        val abc = result.fold(
-            { success -> success },
-            { error -> throw IllegalStateException("Feil ved sjekk av tilgang til personer vha grupper mot sif-abac-pdp ${if (environment == KoinProfile.PREPROD) body else ""}: $error") }
-        )
+        val abc = if (response.status.isSuccess()) {
+            response.bodyAsText()
+        } else {
+            throw IllegalStateException("Feil ved sjekk av tilgang til personer vha grupper mot sif-abac-pdp ${if (environment == KoinProfile.PREPROD) body else ""}: HTTP ${response.status.value} ${response.status.description}")
+        }
 
         return LosObjectMapper.instance.readValue<Tilgangsbeslutning>(abc).harTilgang()
     }

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/infrastruktur/pdl/PdlService.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/infrastruktur/pdl/PdlService.kt
@@ -5,7 +5,6 @@ import io.ktor.client.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
-import no.nav.helse.dusseldorf.ktor.client.buildURL
 import no.nav.helse.dusseldorf.ktor.core.Retry
 import no.nav.helse.dusseldorf.ktor.metrics.Operation
 import no.nav.helse.dusseldorf.oauth2.client.AccessTokenClient
@@ -34,10 +33,7 @@ class PdlService(
     private val log: Logger = LoggerFactory.getLogger(PdlService::class.java)
     private val scopes = setOf(scope)
 
-    private val personUrl = Url.buildURL(
-        baseUrl = baseUrl,
-        pathParts = listOf()
-    ).toString()
+    private val personUrl = baseUrl.toString()
 
     private val graphqlQueryHentPerson = getStringFromResource("/pdl/hentPerson.graphql")
     private val graphqlQueryHentIdent = getStringFromResource("/pdl/hentIdent.graphql")

--- a/src/test/kotlin/no/nav/k9/los/TestConfiguration.kt
+++ b/src/test/kotlin/no/nav/k9/los/TestConfiguration.kt
@@ -1,6 +1,9 @@
 package no.nav.k9.los
 
-import com.github.kittinunf.fuel.httpGet
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import kotlinx.coroutines.runBlocking
 import com.github.tomakehurst.wiremock.WireMockServer
 import no.nav.helse.dusseldorf.testsupport.jws.ClientCredentials
 import no.nav.k9.los.wiremocks.getTpsProxyUrl
@@ -58,5 +61,11 @@ object TestConfiguration {
         return map.toMap()
     }
 
-    private fun String.getAsJson() = JSONObject(this.httpGet().responseString().third.component1())
+    private fun String.getAsJson(): JSONObject {
+        val httpClient = HttpClient()
+        return runBlocking {
+            val response = httpClient.get(this@getAsJson)
+            JSONObject(response.bodyAsText())
+        }
+    }
 }

--- a/src/test/kotlin/no/nav/k9/los/fagsystem/k9sak/K9SakK9SakK9PunsjK9KlageK9TilbakeEventHandlerV2Test.kt
+++ b/src/test/kotlin/no/nav/k9/los/fagsystem/k9sak/K9SakK9SakK9PunsjK9KlageK9TilbakeEventHandlerV2Test.kt
@@ -33,7 +33,7 @@ class K9SakK9SakK9PunsjK9KlageK9TilbakeEventHandlerV2Test : AbstractK9LosIntegra
         val accessToken = mockk<AccessTokenClient>()
         coEvery { accessToken.getAccessToken(any()) } throws Exception("FORVENTET TESTFEIL")
 
-        val azureGraphService = AzureGraphService(accessToken)
+        val azureGraphService = AzureGraphService(accessToken, mockk())
         val oppgaveTjenesteV2 = get<OppgaveTjenesteV2>()
         val eventHandler = K9sakEventHandlerV2(oppgaveTjenesteV2, AksjonspunktHendelseMapper(azureGraphService))
 


### PR DESCRIPTION
- Endre fuel til ktor-client (med http engine fra Java)
- Webproxy kun på Azure-kall, siden det er eneste kall ut på internett
- Fjerner flere ubrukte/unødvendige avhengigheter