### PR TITLE
Erstatt fiktive fødselsnummer med syntetisk fnr

### DIFF
--- a/src/test/kotlin/no/nav/k9/los/pdl/PdlServiceTest.kt
+++ b/src/test/kotlin/no/nav/k9/los/pdl/PdlServiceTest.kt
@@ -11,7 +11,7 @@ class PdlServiceTest {
     @Test
     fun `skal desrialisere personpdl`() {
         val json =
-            "{\n  \"data\": {\n    \"hentPerson\": {\n      \"navn\": [\n        {\n          \"fornavn\": \"GRØNN\",\n          \"mellomnavn\": null,\n          \"etternavn\": \"STAFFELI\",\n          \"forkortetNavn\": \"STAFFELI GRØNN\"\n        }\n      ],\n      \"folkeregisteridentifikator\": [\n        {\n          \"identifikasjonsnummer\": \"19128521618\"\n        }\n      ],\n      \"kjoenn\": [\n        {\n          \"kjoenn\": \"KVINNE\"\n        }\n      ],\n      \"doedsfall\": []\n    }\n  }\n}"
+            "{\n  \"data\": {\n    \"hentPerson\": {\n      \"navn\": [\n        {\n          \"fornavn\": \"GRØNN\",\n          \"mellomnavn\": null,\n          \"etternavn\": \"STAFFELI\",\n          \"forkortetNavn\": \"STAFFELI GRØNN\"\n        }\n      ],\n      \"folkeregisteridentifikator\": [\n        {\n          \"identifikasjonsnummer\": \"17420373147\"\n        }\n      ],\n      \"kjoenn\": [\n        {\n          \"kjoenn\": \"KVINNE\"\n        }\n      ],\n      \"doedsfall\": []\n    }\n  }\n}"
         val readValue = LosObjectMapper.instance.readValue<PersonPdl>(json)
         assertEquals("KVINNE", readValue.data.hentPerson.kjoenn[0].kjoenn)
     }

--- a/src/test/kotlin/no/nav/k9/los/wiremocks/TpsProxyResponseTransformer.kt
+++ b/src/test/kotlin/no/nav/k9/los/wiremocks/TpsProxyResponseTransformer.kt
@@ -43,7 +43,7 @@ private fun getResponse(navIdent: String): String {
             etternavn = "TEST"
             foedselsdato = "1985-07-27"
         }
-        "25037139184" -> {
+        "24420167209" -> {
             fornavn = "ARNE"
             mellomnavn = "BJARNE"
             etternavn = "CARLSEN"


### PR DESCRIPTION
Erstatter fiktive fødselsnummer i testkode med syntetiske personnummer (syntetiske personnummer) som ikke matcher ekte personer.