### PR TITLE
Separer aksjonspunkt

### DIFF
--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/eventtiloppgave/klagetillos/KlageEventTilOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/eventtiloppgave/klagetillos/KlageEventTilOppgaveMapper.kt
@@ -186,6 +186,9 @@ class KlageEventTilOppgaveMapper(
             utledAksjonspunkter(event, oppgaveFeltverdiDtos)
             utledÅpneAksjonspunkter(åpneAksjonspunkter, oppgaveFeltverdiDtos)
             utledLøsbartAksjonspunkt(event.behandlingSteg, åpneAksjonspunkter, oppgaveFeltverdiDtos)
+            utledUtførteAksjonspunkter(event, oppgaveFeltverdiDtos)
+            utledAvbrutteAksjonspunkter(event, oppgaveFeltverdiDtos)
+            utledFremtidigeAksjonspunkter(event.behandlingSteg, åpneAksjonspunkter, oppgaveFeltverdiDtos)
 
             utledTidspunktOversendtKabal(event, oppgaveFeltverdiDtos)
 
@@ -283,6 +286,78 @@ class KlageEventTilOppgaveMapper(
                 oppgaveFeltverdiDtos.add(
                     OppgaveFeltverdiDto(
                         nøkkel = "aksjonspunkt",
+                        verdi = null
+                    )
+                )
+            }
+        }
+
+        private fun utledUtførteAksjonspunkter(
+            event: K9KlageEventDto,
+            oppgaveFeltverdiDtos: MutableList<OppgaveFeltverdiDto>
+        ) {
+            val utførte = event.aksjonspunkttilstander.filter { it.status == AksjonspunktStatus.UTFØRT }
+            if (utførte.isNotEmpty()) {
+                oppgaveFeltverdiDtos.addAll(utførte.map { aksjonspunkttilstand ->
+                    OppgaveFeltverdiDto(
+                        nøkkel = "utførtAksjonspunkt",
+                        verdi = KLAGE_PREFIX + aksjonspunkttilstand.aksjonspunktKode
+                    )
+                })
+            } else {
+                oppgaveFeltverdiDtos.add(
+                    OppgaveFeltverdiDto(
+                        nøkkel = "utførtAksjonspunkt",
+                        verdi = null
+                    )
+                )
+            }
+        }
+
+        private fun utledAvbrutteAksjonspunkter(
+            event: K9KlageEventDto,
+            oppgaveFeltverdiDtos: MutableList<OppgaveFeltverdiDto>
+        ) {
+            val avbrutte = event.aksjonspunkttilstander.filter { it.status == AksjonspunktStatus.AVBRUTT }
+            if (avbrutte.isNotEmpty()) {
+                oppgaveFeltverdiDtos.addAll(avbrutte.map { aksjonspunkttilstand ->
+                    OppgaveFeltverdiDto(
+                        nøkkel = "avbruttAksjonspunkt",
+                        verdi = KLAGE_PREFIX + aksjonspunkttilstand.aksjonspunktKode
+                    )
+                })
+            } else {
+                oppgaveFeltverdiDtos.add(
+                    OppgaveFeltverdiDto(
+                        nøkkel = "avbruttAksjonspunkt",
+                        verdi = null
+                    )
+                )
+            }
+        }
+
+        private fun utledFremtidigeAksjonspunkter(
+            behandlingSteg: String?,
+            åpneAksjonspunkter: List<Aksjonspunkttilstand>,
+            oppgaveFeltverdiDtos: MutableList<OppgaveFeltverdiDto>
+        ) {
+            val fremtidige = åpneAksjonspunkter.filter { åpentAksjonspunkt ->
+                val aksjonspunktDefinisjon = AksjonspunktDefinisjon.fraKode(åpentAksjonspunkt.aksjonspunktKode)
+                aksjonspunktDefinisjon.erAutopunkt()
+                    || aksjonspunktDefinisjon.behandlingSteg == null
+                    || aksjonspunktDefinisjon.behandlingSteg.kode != behandlingSteg
+            }
+            if (fremtidige.isNotEmpty()) {
+                oppgaveFeltverdiDtos.addAll(fremtidige.map { aksjonspunkttilstand ->
+                    OppgaveFeltverdiDto(
+                        nøkkel = "fremtidigAksjonspunkt",
+                        verdi = KLAGE_PREFIX + aksjonspunkttilstand.aksjonspunktKode
+                    )
+                })
+            } else {
+                oppgaveFeltverdiDtos.add(
+                    OppgaveFeltverdiDto(
+                        nøkkel = "fremtidigAksjonspunkt",
                         verdi = null
                     )
                 )

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/eventtiloppgave/saktillos/SakEventTilOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/eventtiloppgave/saktillos/SakEventTilOppgaveMapper.kt
@@ -214,6 +214,9 @@ class SakEventTilOppgaveMapper(
 
             utledAksjonspunkter(event, oppgaveFeltverdiDtos)
             utledÅpneAksjonspunkter(event.behandlingSteg, åpneAksjonspunkter, oppgaveFeltverdiDtos)
+            utledUtførteAksjonspunkter(event, oppgaveFeltverdiDtos)
+            utledAvbrutteAksjonspunkter(event, oppgaveFeltverdiDtos)
+            utledFremtidigeAksjonspunkter(event.behandlingSteg, åpneAksjonspunkter, oppgaveFeltverdiDtos)
             utledVenteÅrsakOgFrist(åpneAksjonspunkter, oppgaveFeltverdiDtos)
             utledAutomatiskBehandletFlagg(oppgaveFeltverdiDtos, event)
             utledSøknadsårsaker(event, oppgaveFeltverdiDtos)
@@ -648,6 +651,78 @@ class SakEventTilOppgaveMapper(
                 oppgaveFeltverdiDtos.add(
                     OppgaveFeltverdiDto(
                         nøkkel = "aksjonspunkt",
+                        verdi = null
+                    )
+                )
+            }
+        }
+
+        private fun utledUtførteAksjonspunkter(
+            event: K9SakEventDto,
+            oppgaveFeltverdiDtos: MutableList<OppgaveFeltverdiDto>
+        ) {
+            val utførte = event.aksjonspunktTilstander.filter { it.status == AksjonspunktStatus.UTFØRT }
+            if (utførte.isNotEmpty()) {
+                oppgaveFeltverdiDtos.addAll(utførte.map { aksjonspunktTilstand ->
+                    OppgaveFeltverdiDto(
+                        nøkkel = "utførtAksjonspunkt",
+                        verdi = aksjonspunktTilstand.aksjonspunktKode
+                    )
+                })
+            } else {
+                oppgaveFeltverdiDtos.add(
+                    OppgaveFeltverdiDto(
+                        nøkkel = "utførtAksjonspunkt",
+                        verdi = null
+                    )
+                )
+            }
+        }
+
+        private fun utledAvbrutteAksjonspunkter(
+            event: K9SakEventDto,
+            oppgaveFeltverdiDtos: MutableList<OppgaveFeltverdiDto>
+        ) {
+            val avbrutte = event.aksjonspunktTilstander.filter { it.status == AksjonspunktStatus.AVBRUTT }
+            if (avbrutte.isNotEmpty()) {
+                oppgaveFeltverdiDtos.addAll(avbrutte.map { aksjonspunktTilstand ->
+                    OppgaveFeltverdiDto(
+                        nøkkel = "avbruttAksjonspunkt",
+                        verdi = aksjonspunktTilstand.aksjonspunktKode
+                    )
+                })
+            } else {
+                oppgaveFeltverdiDtos.add(
+                    OppgaveFeltverdiDto(
+                        nøkkel = "avbruttAksjonspunkt",
+                        verdi = null
+                    )
+                )
+            }
+        }
+
+        private fun utledFremtidigeAksjonspunkter(
+            behandlingSteg: String?,
+            åpneAksjonspunkter: List<AksjonspunktTilstandDto>,
+            oppgaveFeltverdiDtos: MutableList<OppgaveFeltverdiDto>
+        ) {
+            val fremtidige = åpneAksjonspunkter.filter { åpentAksjonspunkt ->
+                val aksjonspunktDefinisjon = AksjonspunktDefinisjon.fraKode(åpentAksjonspunkt.aksjonspunktKode)
+                aksjonspunktDefinisjon.erAutopunkt()
+                    || aksjonspunktDefinisjon.behandlingSteg == null
+                    || aksjonspunktDefinisjon.behandlingSteg.kode != behandlingSteg
+            }
+            if (fremtidige.isNotEmpty()) {
+                oppgaveFeltverdiDtos.addAll(fremtidige.map { aksjonspunktTilstand ->
+                    OppgaveFeltverdiDto(
+                        nøkkel = "fremtidigAksjonspunkt",
+                        verdi = aksjonspunktTilstand.aksjonspunktKode
+                    )
+                })
+            } else {
+                oppgaveFeltverdiDtos.add(
+                    OppgaveFeltverdiDto(
+                        nøkkel = "fremtidigAksjonspunkt",
                         verdi = null
                     )
                 )

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/eventtiloppgave/tilbaketillos/TilbakeEventTilOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/eventtiloppgave/tilbaketillos/TilbakeEventTilOppgaveMapper.kt
@@ -129,6 +129,8 @@ class TilbakeEventTilOppgaveMapper {
             val oppgaveFeltverdiDtos = mapEnkeltverdier(event, forrigeOppgave)
 
             utledAksjonspunkter(event, oppgaveFeltverdiDtos)
+            utledUtførteAksjonspunkter(event, oppgaveFeltverdiDtos)
+            utledAvbrutteAksjonspunkter(event, oppgaveFeltverdiDtos)
             utledAutomatiskBehandletFlagg(event, forrigeOppgave, oppgaveFeltverdiDtos)
             return oppgaveFeltverdiDtos
         }
@@ -262,6 +264,54 @@ class TilbakeEventTilOppgaveMapper {
                 oppgaveFeltverdiDtos.add(
                     OppgaveFeltverdiDto(
                         nøkkel = "løsbartAksjonspunkt",
+                        verdi = null
+                    )
+                )
+            }
+        }
+
+        private fun utledUtførteAksjonspunkter(
+            event: K9TilbakeEventDto,
+            oppgaveFeltverdiDtos: MutableList<OppgaveFeltverdiDto>
+        ) {
+            val utførte = event.aksjonspunktKoderMedStatusListe
+                .filter { it.value == AksjonspunktStatus.UTFØRT.kode }
+
+            if (utførte.isNotEmpty()) {
+                oppgaveFeltverdiDtos.addAll(utførte.map {
+                    OppgaveFeltverdiDto(
+                        nøkkel = "utførtAksjonspunkt",
+                        verdi = it.key
+                    )
+                })
+            } else {
+                oppgaveFeltverdiDtos.add(
+                    OppgaveFeltverdiDto(
+                        nøkkel = "utførtAksjonspunkt",
+                        verdi = null
+                    )
+                )
+            }
+        }
+
+        private fun utledAvbrutteAksjonspunkter(
+            event: K9TilbakeEventDto,
+            oppgaveFeltverdiDtos: MutableList<OppgaveFeltverdiDto>
+        ) {
+            val avbrutte = event.aksjonspunktKoderMedStatusListe
+                .filter { it.value == AksjonspunktStatus.AVBRUTT.kode }
+
+            if (avbrutte.isNotEmpty()) {
+                oppgaveFeltverdiDtos.addAll(avbrutte.map {
+                    OppgaveFeltverdiDto(
+                        nøkkel = "avbruttAksjonspunkt",
+                        verdi = it.key
+                    )
+                })
+            } else {
+                oppgaveFeltverdiDtos.add(
+                    OppgaveFeltverdiDto(
+                        nøkkel = "avbruttAksjonspunkt",
                         verdi = null
                     )
                 )

--- a/src/main/resources/adapterdefinisjoner/k9-feltdefinisjoner-v2.json
+++ b/src/main/resources/adapterdefinisjoner/k9-feltdefinisjoner-v2.json
@@ -226,7 +226,7 @@
       "beskrivelse": "Aksjonspunkter som er utført",
       "listetype": true,
       "tolkesSom": "String",
-      "synlighet": "UNDER_STREKEN",
+      "synlighet": "SKJULT",
       "kodeverkreferanse": {
         "område": "K9",
         "eksternId": "Aksjonspunkt"
@@ -238,7 +238,7 @@
       "beskrivelse": "Aksjonspunkter som er avbrutt",
       "listetype": true,
       "tolkesSom": "String",
-      "synlighet": "UNDER_STREKEN",
+      "synlighet": "SKJULT",
       "kodeverkreferanse": {
         "område": "K9",
         "eksternId": "Aksjonspunkt"
@@ -250,7 +250,7 @@
       "beskrivelse": "Åpne aksjonspunkter som ikke kan løses i steget behandlingen står i nå",
       "listetype": true,
       "tolkesSom": "String",
-      "synlighet": "UNDER_STREKEN",
+      "synlighet": "SKJULT",
       "kodeverkreferanse": {
         "område": "K9",
         "eksternId": "Aksjonspunkt"

--- a/src/main/resources/adapterdefinisjoner/k9-feltdefinisjoner-v2.json
+++ b/src/main/resources/adapterdefinisjoner/k9-feltdefinisjoner-v2.json
@@ -210,11 +210,47 @@
     },
     {
       "id": "løsbartAksjonspunkt",
-      "visningsnavn": "Aksjonspunkt som kan løses",
+      "visningsnavn": "Aksjonspunkt: løsbart",
       "beskrivelse": "Åpne aksjonspunkt som er løsbart akkurat nå, fordi de hører til steget behandlingen står i",
       "listetype": false,
       "tolkesSom": "String",
       "synlighet": "OVER_STREKEN",
+      "kodeverkreferanse": {
+        "område": "K9",
+        "eksternId": "Aksjonspunkt"
+      }
+    },
+    {
+      "id": "utførtAksjonspunkt",
+      "visningsnavn": "Aksjonspunkt: utførte",
+      "beskrivelse": "Aksjonspunkter som er utført",
+      "listetype": true,
+      "tolkesSom": "String",
+      "synlighet": "UNDER_STREKEN",
+      "kodeverkreferanse": {
+        "område": "K9",
+        "eksternId": "Aksjonspunkt"
+      }
+    },
+    {
+      "id": "avbruttAksjonspunkt",
+      "visningsnavn": "Aksjonspunkt: avbrutte",
+      "beskrivelse": "Aksjonspunkter som er avbrutt",
+      "listetype": true,
+      "tolkesSom": "String",
+      "synlighet": "UNDER_STREKEN",
+      "kodeverkreferanse": {
+        "område": "K9",
+        "eksternId": "Aksjonspunkt"
+      }
+    },
+    {
+      "id": "fremtidigAksjonspunkt",
+      "visningsnavn": "Aksjonspunkt: fremtidige",
+      "beskrivelse": "Åpne aksjonspunkter som ikke kan løses i steget behandlingen står i nå",
+      "listetype": true,
+      "tolkesSom": "String",
+      "synlighet": "UNDER_STREKEN",
       "kodeverkreferanse": {
         "område": "K9",
         "eksternId": "Aksjonspunkt"

--- a/src/main/resources/adapterdefinisjoner/k9-oppgavetyper-k9klage.json
+++ b/src/main/resources/adapterdefinisjoner/k9-oppgavetyper-k9klage.json
@@ -142,6 +142,21 @@
           "påkrevd": false
         },
         {
+          "id": "utførtAksjonspunkt",
+          "visPåOppgave": true,
+          "påkrevd": false
+        },
+        {
+          "id": "avbruttAksjonspunkt",
+          "visPåOppgave": true,
+          "påkrevd": false
+        },
+        {
+          "id": "fremtidigAksjonspunkt",
+          "visPåOppgave": true,
+          "påkrevd": false
+        },
+        {
           "id": "avventerSaksbehandler",
           "visPåOppgave": true,
           "påkrevd": true

--- a/src/main/resources/adapterdefinisjoner/k9-oppgavetyper-k9sak.json
+++ b/src/main/resources/adapterdefinisjoner/k9-oppgavetyper-k9sak.json
@@ -137,6 +137,21 @@
           "påkrevd": false
         },
         {
+          "id": "utførtAksjonspunkt",
+          "visPåOppgave": true,
+          "påkrevd": false
+        },
+        {
+          "id": "avbruttAksjonspunkt",
+          "visPåOppgave": true,
+          "påkrevd": false
+        },
+        {
+          "id": "fremtidigAksjonspunkt",
+          "visPåOppgave": true,
+          "påkrevd": false
+        },
+        {
           "id": "avventerSøker",
           "visPåOppgave": false,
           "påkrevd": true

--- a/src/main/resources/adapterdefinisjoner/k9-oppgavetyper-k9tilbake.json
+++ b/src/main/resources/adapterdefinisjoner/k9-oppgavetyper-k9tilbake.json
@@ -92,6 +92,16 @@
           "påkrevd": false
         },
         {
+          "id": "utførtAksjonspunkt",
+          "visPåOppgave": true,
+          "påkrevd": false
+        },
+        {
+          "id": "avbruttAksjonspunkt",
+          "visPåOppgave": true,
+          "påkrevd": false
+        },
+        {
           "id": "behandlingssteg",
           "visPåOppgave": false,
           "påkrevd": false

--- a/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/eventtiloppgave/klagetillos/EventTilDtoMapperTest.kt
+++ b/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/eventtiloppgave/klagetillos/EventTilDtoMapperTest.kt
@@ -2,61 +2,68 @@ package no.nav.k9.los.nyoppgavestyring.domeneadaptere.k9.eventtiloppgave.klageti
 
 import assertk.assertThat
 import assertk.assertions.any
+import assertk.assertions.containsOnly
 import assertk.assertions.matchesPredicate
 import no.nav.k9.klage.kodeverk.Fagsystem
 import no.nav.k9.klage.kodeverk.behandling.BehandlingStatus
 import no.nav.k9.klage.kodeverk.behandling.BehandlingStegType
+import no.nav.k9.klage.kodeverk.behandling.aksjonspunkt.AksjonspunktDefinisjon
 import no.nav.k9.klage.kodeverk.behandling.aksjonspunkt.AksjonspunktStatus
 import no.nav.k9.klage.kodeverk.behandling.oppgavetillos.EventHendelse
 import no.nav.k9.klage.kontrakt.behandling.oppgavetillos.Aksjonspunkttilstand
 import no.nav.k9.klage.typer.AktørId
 import no.nav.k9.klage.typer.Periode
 import no.nav.k9.los.nyoppgavestyring.domeneadaptere.k9.eventmottak.klage.K9KlageEventDto
+import no.nav.k9.los.nyoppgavestyring.mottak.oppgave.OppgaveFeltverdiDto
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 
+private fun verdierFor(feltverdier: List<OppgaveFeltverdiDto>, nøkkel: String): List<String?> =
+    feltverdier.filter { it.nøkkel == nøkkel }.map { it.verdi }
+
+private fun lagKlageEvent(
+    aksjonspunkttilstander: List<Aksjonspunkttilstand>,
+    behandlingSteg: String = BehandlingStegType.VURDER_KLAGE_FØRSTEINSTANS.kode,
+    behandlingStatus: String = BehandlingStatus.UTREDES.kode
+) = K9KlageEventDto(
+    eksternId = UUID.randomUUID(),
+    fagsystem = Fagsystem.K9SAK,
+    eventTid = LocalDateTime.now(),
+    opprettetBehandling = LocalDateTime.now(),
+    aksjonspunkttilstander = aksjonspunkttilstander,
+    påklagdBehandlingType = null,
+    påklagdBehandlingId = null,
+    utenlandstilsnitt = null,
+    behandlingstidFrist = LocalDate.now(),
+    saksnummer = "test",
+    aktørId = "test",
+    eventHendelse = EventHendelse.AKSJONSPUNKT_OPPRETTET,
+    behandlingStatus = behandlingStatus,
+    behandlingSteg = behandlingSteg,
+    behandlendeEnhet = "test",
+    ansvarligBeslutter = "test",
+    ansvarligSaksbehandler = "test",
+    resultatType = "test",
+    ytelseTypeKode = "test",
+    behandlingTypeKode = "test",
+    fagsakPeriode = Periode(LocalDate.now().minusDays(1), LocalDate.now()),
+    pleietrengendeAktørId = AktørId(2L),
+    relatertPartAktørId = AktørId(3L),
+    vedtaksdato = LocalDate.now(),
+    behandlingsårsaker = listOf("test"),
+)
+
+private fun aksjonspunkttilstand(kode: String, status: AksjonspunktStatus) =
+    Aksjonspunkttilstand(kode, status, null, null, LocalDateTime.now(), LocalDateTime.now())
+
 class EventTilDtoMapperTest {
     @Test
     fun `5016 skal gi til beslutter`() {
-        val k9KlageEvent = K9KlageEventDto(
-            eksternId = UUID.randomUUID(),
-            fagsystem = Fagsystem.K9SAK,
-            eventTid = LocalDateTime.now(),
-            opprettetBehandling = LocalDateTime.now(),
-            aksjonspunkttilstander = listOf(
-                Aksjonspunkttilstand(
-                    "5016",
-                    AksjonspunktStatus.OPPRETTET,
-                    null,
-                    null,
-                    LocalDateTime.now(),
-                    LocalDateTime.now()
-                )
-            ),
-            påklagdBehandlingType = null,
-            påklagdBehandlingId = null,
-            utenlandstilsnitt = null,
-            behandlingstidFrist = LocalDate.now(),
-            saksnummer = "test",
-            aktørId = "test",
-            eventHendelse = EventHendelse.AKSJONSPUNKT_OPPRETTET,
-            behandlingStatus = BehandlingStatus.OPPRETTET.kode,
-            behandlingSteg = BehandlingStegType.VURDER_KLAGE_FØRSTEINSTANS.kode,
-            behandlendeEnhet = "test",
-            ansvarligBeslutter = "test",
-            ansvarligSaksbehandler = "test",
-            resultatType = "test",
-            ytelseTypeKode = "test",
-            behandlingTypeKode = "test",
-            fagsakPeriode = Periode(LocalDate.now().minusDays(1), LocalDate.now()),
-            pleietrengendeAktørId = AktørId(2L),
-            relatertPartAktørId = AktørId(3L),
-            vedtaksdato = LocalDate.now(),
-            behandlingsårsaker = listOf("test"),
+        val k9KlageEvent = lagKlageEvent(
+            aksjonspunkttilstander = listOf(aksjonspunkttilstand("5016", AksjonspunktStatus.OPPRETTET)),
         )
-
 
         val oppgaveDto = KlageEventTilOppgaveMapper.lagOppgaveDto(k9KlageEvent, null)
 
@@ -65,35 +72,78 @@ class EventTilDtoMapperTest {
 
     @Test
     fun `uten 5016 skal ikke gi til beslutter`() {
-        val k9KlageEvent = K9KlageEventDto(
-            eksternId = UUID.randomUUID(),
-            fagsystem = Fagsystem.K9SAK,
-            eventTid = LocalDateTime.now(),
-            opprettetBehandling = LocalDateTime.now(),
-            aksjonspunkttilstander = listOf(),
-            påklagdBehandlingType = null,
-            påklagdBehandlingId = null,
-            utenlandstilsnitt = null,
-            behandlingstidFrist = LocalDate.now(),
-            saksnummer = "test",
-            aktørId = "test",
-            eventHendelse = EventHendelse.AKSJONSPUNKT_OPPRETTET,
-            behandlingStatus = BehandlingStatus.OPPRETTET.kode,
-            behandlingSteg = BehandlingStegType.VURDER_KLAGE_FØRSTEINSTANS.kode,
-            behandlendeEnhet = "test",
-            ansvarligBeslutter = "test",
-            ansvarligSaksbehandler = "test",
-            resultatType = "test",
-            ytelseTypeKode = "test",
-            behandlingTypeKode = "test",
-            fagsakPeriode = Periode(LocalDate.now().minusDays(1), LocalDate.now()),
-            pleietrengendeAktørId = AktørId(2L),
-            relatertPartAktørId = AktørId(3L),
-            vedtaksdato = LocalDate.now(),
-            behandlingsårsaker = listOf("test"),
-        )
+        val k9KlageEvent = lagKlageEvent(aksjonspunkttilstander = listOf())
+
         val oppgaveDto = KlageEventTilOppgaveMapper.lagOppgaveDto(k9KlageEvent, null)
 
         assertThat(oppgaveDto.feltverdier).any { it.matchesPredicate { feltverdi -> feltverdi.nøkkel == "liggerHosBeslutter" && feltverdi.verdi == "false" } }
+    }
+
+    @Test
+    fun `klage med blanding av aksjonspunktstatuser gir riktige aksjonspunktfelt`() {
+        val vurderKlageAP = AksjonspunktDefinisjon.MANUELL_VURDERING_AV_KLAGE_NFP
+        val fatterVedtakAP = AksjonspunktDefinisjon.FATTER_VEDTAK
+
+        val k9KlageEvent = lagKlageEvent(
+            behandlingSteg = vurderKlageAP.behandlingSteg.kode,
+            aksjonspunkttilstander = listOf(
+                aksjonspunkttilstand(vurderKlageAP.kode, AksjonspunktStatus.OPPRETTET),
+                aksjonspunkttilstand(fatterVedtakAP.kode, AksjonspunktStatus.UTFØRT),
+            ),
+        )
+
+        val oppgaveDto = KlageEventTilOppgaveMapper.lagOppgaveDto(k9KlageEvent, null)
+        val feltverdier = oppgaveDto.feltverdier
+
+        // Verdier skal ha KLAGE-prefix
+        val prefix = KlageEventTilOppgaveMapper.KLAGE_PREFIX
+
+        assertThat(verdierFor(feltverdier, "utførtAksjonspunkt")).containsOnly(
+            prefix + fatterVedtakAP.kode
+        )
+        assertThat(verdierFor(feltverdier, "avbruttAksjonspunkt")).containsOnly(null)
+
+        // vurderKlageAP er OPPRETTET og i nåværende steg → løsbart, ikke fremtidig
+        assertThat(verdierFor(feltverdier, "fremtidigAksjonspunkt")).containsOnly(null)
+        assertThat(verdierFor(feltverdier, "løsbartAksjonspunkt")).containsOnly(
+            prefix + vurderKlageAP.kode
+        )
+
+        // Eksisterende felt
+        assertThat(verdierFor(feltverdier, "aksjonspunkt")).containsOnly(
+            prefix + vurderKlageAP.kode,
+            prefix + fatterVedtakAP.kode
+        )
+        assertThat(verdierFor(feltverdier, "aktivtAksjonspunkt")).containsOnly(
+            prefix + vurderKlageAP.kode
+        )
+    }
+
+    @Test
+    fun `klage hos beslutter med utført og avbrutt aksjonspunkt`() {
+        val fatterVedtakAP = AksjonspunktDefinisjon.FATTER_VEDTAK
+        val vurderKlageAP = AksjonspunktDefinisjon.MANUELL_VURDERING_AV_KLAGE_NFP
+
+        val k9KlageEvent = lagKlageEvent(
+            behandlingSteg = fatterVedtakAP.behandlingSteg.kode,
+            behandlingStatus = BehandlingStatus.FATTER_VEDTAK.kode,
+            aksjonspunkttilstander = listOf(
+                aksjonspunkttilstand(fatterVedtakAP.kode, AksjonspunktStatus.OPPRETTET),
+                aksjonspunkttilstand(vurderKlageAP.kode, AksjonspunktStatus.AVBRUTT),
+            ),
+        )
+
+        val oppgaveDto = KlageEventTilOppgaveMapper.lagOppgaveDto(k9KlageEvent, null)
+        val feltverdier = oppgaveDto.feltverdier
+        val prefix = KlageEventTilOppgaveMapper.KLAGE_PREFIX
+
+        assertThat(verdierFor(feltverdier, "utførtAksjonspunkt")).containsOnly(null)
+        assertThat(verdierFor(feltverdier, "avbruttAksjonspunkt")).containsOnly(
+            prefix + vurderKlageAP.kode
+        )
+        assertThat(verdierFor(feltverdier, "fremtidigAksjonspunkt")).containsOnly(null)
+        assertThat(verdierFor(feltverdier, "løsbartAksjonspunkt")).containsOnly(
+            prefix + fatterVedtakAP.kode
+        )
     }
 }

--- a/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/eventtiloppgave/saktillos/EventTilDtoMapperTest.kt
+++ b/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/eventtiloppgave/saktillos/EventTilDtoMapperTest.kt
@@ -2,15 +2,22 @@ package no.nav.k9.los.nyoppgavestyring.domeneadaptere.k9.eventtiloppgave.saktill
 
 import assertk.assertThat
 import assertk.assertions.any
+import assertk.assertions.containsOnly
+import assertk.assertions.isEmpty
 import assertk.assertions.matchesPredicate
+import no.nav.k9.kodeverk.behandling.aksjonspunkt.AksjonspunktDefinisjon
 import no.nav.k9.los.AbstractK9LosIntegrationTest
 import no.nav.k9.los.nyoppgavestyring.domeneadaptere.k9.eventmottak.EventHendelse
 import no.nav.k9.los.nyoppgavestyring.domeneadaptere.k9.eventmottak.K9SakEventDtoBuilder
 import no.nav.k9.los.nyoppgavestyring.domeneadaptere.k9.eventmottak.eventlager.EventLagret
 import no.nav.k9.los.nyoppgavestyring.infrastruktur.utils.LosObjectMapper
+import no.nav.k9.los.nyoppgavestyring.mottak.oppgave.OppgaveFeltverdiDto
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.koin.test.get
+
+private fun verdierFor(feltverdier: List<OppgaveFeltverdiDto>, nøkkel: String): List<String?> =
+    feltverdier.filter { it.nøkkel == nøkkel }.map { it.verdi }
 
 class EventTilDtoMapperTest: AbstractK9LosIntegrationTest() {
     @Test
@@ -61,5 +68,116 @@ class EventTilDtoMapperTest: AbstractK9LosIntegrationTest() {
             ), null, 0)
 
         assertTrue(innsending is no.nav.k9.los.nyoppgavestyring.mottak.oppgave.NyOppgaveversjon)
+    }
+
+    @Test
+    fun `returFraBeslutter gir riktige aksjonspunktfelt`() {
+        val event = K9SakEventDtoBuilder().returFraBeslutter().build()
+        val oppgaveDto = SakEventTilOppgaveMapper.lagOppgaveDto(event, null)
+        val feltverdier = oppgaveDto.feltverdier
+
+        // KONTROLLER_LEGEERKLÆRING=OPPRETTET, FORESLÅ_VEDTAK=AVBRUTT, FATTER_VEDTAK=UTFØRT
+        // behandlingSteg=FORESLÅ_VEDTAK
+
+        assertThat(verdierFor(feltverdier, "utførtAksjonspunkt")).containsOnly(
+            AksjonspunktDefinisjon.FATTER_VEDTAK.kode
+        )
+        assertThat(verdierFor(feltverdier, "avbruttAksjonspunkt")).containsOnly(
+            AksjonspunktDefinisjon.FORESLÅ_VEDTAK.kode
+        )
+        // KONTROLLER_LEGEERKLÆRING er OPPRETTET men i annet steg enn FORESLÅ_VEDTAK → fremtidig
+        assertThat(verdierFor(feltverdier, "fremtidigAksjonspunkt")).containsOnly(
+            AksjonspunktDefinisjon.KONTROLLER_LEGEERKLÆRING.kode
+        )
+        // Ingen OPPRETTET AP matcher nåværende steg → løsbartAksjonspunkt ikke satt
+        assertThat(verdierFor(feltverdier, "løsbartAksjonspunkt")).isEmpty()
+
+        // Eksisterende felt: alle aksjonspunkter uavhengig av status
+        assertThat(verdierFor(feltverdier, "aksjonspunkt")).containsOnly(
+            AksjonspunktDefinisjon.KONTROLLER_LEGEERKLÆRING.kode,
+            AksjonspunktDefinisjon.FORESLÅ_VEDTAK.kode,
+            AksjonspunktDefinisjon.FATTER_VEDTAK.kode
+        )
+        // Eksisterende felt: kun OPPRETTET aksjonspunkter
+        assertThat(verdierFor(feltverdier, "aktivtAksjonspunkt")).containsOnly(
+            AksjonspunktDefinisjon.KONTROLLER_LEGEERKLÆRING.kode
+        )
+    }
+
+    @Test
+    fun `hosBeslutter gir riktige aksjonspunktfelt`() {
+        val event = K9SakEventDtoBuilder().hosBeslutter().build()
+        val oppgaveDto = SakEventTilOppgaveMapper.lagOppgaveDto(event, null)
+        val feltverdier = oppgaveDto.feltverdier
+
+        // KONTROLLER_LEGEERKLÆRING=UTFØRT, FORESLÅ_VEDTAK=UTFØRT, FATTER_VEDTAK=OPPRETTET
+        // behandlingSteg=FATTE_VEDTAK
+
+        assertThat(verdierFor(feltverdier, "utførtAksjonspunkt")).containsOnly(
+            AksjonspunktDefinisjon.KONTROLLER_LEGEERKLÆRING.kode,
+            AksjonspunktDefinisjon.FORESLÅ_VEDTAK.kode
+        )
+        assertThat(verdierFor(feltverdier, "avbruttAksjonspunkt")).containsOnly(null)
+        // FATTER_VEDTAK er OPPRETTET og i nåværende steg → ikke fremtidig
+        assertThat(verdierFor(feltverdier, "fremtidigAksjonspunkt")).containsOnly(null)
+        // FATTER_VEDTAK er løsbart (manuell, matcher steget)
+        assertThat(verdierFor(feltverdier, "løsbartAksjonspunkt")).containsOnly(
+            AksjonspunktDefinisjon.FATTER_VEDTAK.kode
+        )
+    }
+
+    @Test
+    fun `avsluttet gir kun utførte aksjonspunktfelt`() {
+        val event = K9SakEventDtoBuilder().avsluttet().build()
+        val oppgaveDto = SakEventTilOppgaveMapper.lagOppgaveDto(event, null)
+        val feltverdier = oppgaveDto.feltverdier
+
+        // Alle tre aksjonspunkter er UTFØRT
+        assertThat(verdierFor(feltverdier, "utførtAksjonspunkt")).containsOnly(
+            AksjonspunktDefinisjon.KONTROLLER_LEGEERKLÆRING.kode,
+            AksjonspunktDefinisjon.FORESLÅ_VEDTAK.kode,
+            AksjonspunktDefinisjon.FATTER_VEDTAK.kode
+        )
+        assertThat(verdierFor(feltverdier, "avbruttAksjonspunkt")).containsOnly(null)
+        assertThat(verdierFor(feltverdier, "fremtidigAksjonspunkt")).containsOnly(null)
+    }
+
+    @Test
+    fun `opprettet uten aksjonspunkter gir tomme aksjonspunktfelt`() {
+        val event = K9SakEventDtoBuilder().opprettet().build()
+        val oppgaveDto = SakEventTilOppgaveMapper.lagOppgaveDto(event, null)
+        val feltverdier = oppgaveDto.feltverdier
+
+        assertThat(verdierFor(feltverdier, "utførtAksjonspunkt")).containsOnly(null)
+        assertThat(verdierFor(feltverdier, "avbruttAksjonspunkt")).containsOnly(null)
+        assertThat(verdierFor(feltverdier, "fremtidigAksjonspunkt")).containsOnly(null)
+    }
+
+    @Test
+    fun `returFraBeslutterOpptjening gir riktige aksjonspunktfelt med alle tre statuser og autopunkt`() {
+        val event = K9SakEventDtoBuilder().returFraBeslutterOpptjening().build()
+        val oppgaveDto = SakEventTilOppgaveMapper.lagOppgaveDto(event, null)
+        val feltverdier = oppgaveDto.feltverdier
+
+        // VURDER_OPPTJENINGSVILKÅRET=OPPRETTET, FASTSETT_BEREGNINGSGRUNNLAG_AT_FL=AVBRUTT,
+        // KONTROLLER_LEGEERKLÆRING=UTFØRT, FORESLÅ_VEDTAK=AVBRUTT, FATTER_VEDTAK=UTFØRT,
+        // AUTO_MANUELT_SATT_PÅ_VENT=UTFØRT (autopunkt)
+        // behandlingSteg=VURDER_OPPTJENINGSVILKÅR
+
+        assertThat(verdierFor(feltverdier, "utførtAksjonspunkt")).containsOnly(
+            AksjonspunktDefinisjon.KONTROLLER_LEGEERKLÆRING.kode,
+            AksjonspunktDefinisjon.FATTER_VEDTAK.kode,
+            AksjonspunktDefinisjon.AUTO_MANUELT_SATT_PÅ_VENT.kode
+        )
+        assertThat(verdierFor(feltverdier, "avbruttAksjonspunkt")).containsOnly(
+            AksjonspunktDefinisjon.FASTSETT_BEREGNINGSGRUNNLAG_ARBEIDSTAKER_FRILANS.kode,
+            AksjonspunktDefinisjon.FORESLÅ_VEDTAK.kode
+        )
+        // VURDER_OPPTJENINGSVILKÅRET er OPPRETTET og i nåværende steg → ikke fremtidig
+        assertThat(verdierFor(feltverdier, "fremtidigAksjonspunkt")).containsOnly(null)
+        // VURDER_OPPTJENINGSVILKÅRET er løsbart
+        assertThat(verdierFor(feltverdier, "løsbartAksjonspunkt")).containsOnly(
+            AksjonspunktDefinisjon.VURDER_OPPTJENINGSVILKÅRET.kode
+        )
     }
 }

--- a/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/eventtiloppgave/tilbaketillos/EventTilDtoMapperTest.kt
+++ b/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/eventtiloppgave/tilbaketillos/EventTilDtoMapperTest.kt
@@ -2,9 +2,15 @@ package no.nav.k9.los.nyoppgavestyring.domeneadaptere.k9.eventtiloppgave.tilbake
 
 import assertk.assertThat
 import assertk.assertions.any
+import assertk.assertions.containsOnly
 import assertk.assertions.matchesPredicate
 import no.nav.k9.los.nyoppgavestyring.domeneadaptere.k9.eventmottak.K9TilbakeEventDtoBuilder
+import no.nav.k9.los.nyoppgavestyring.domeneadaptere.k9.eventmottak.tilbakekrav.AksjonspunktDefinisjonK9Tilbake
+import no.nav.k9.los.nyoppgavestyring.mottak.oppgave.OppgaveFeltverdiDto
 import org.junit.jupiter.api.Test
+
+private fun verdierFor(feltverdier: List<OppgaveFeltverdiDto>, nøkkel: String): List<String?> =
+    feltverdier.filter { it.nøkkel == nøkkel }.map { it.verdi }
 
 class EventTilDtoMapperTest {
     @Test
@@ -21,5 +27,121 @@ class EventTilDtoMapperTest {
         val oppgaveDto = TilbakeEventTilOppgaveMapper.lagOppgaveDto(k9TilbakeEvent, null)
 
         assertThat(oppgaveDto.feltverdier).any { it.matchesPredicate { feltverdi -> feltverdi.nøkkel == "liggerHosBeslutter" && feltverdi.verdi == "false"} }
+    }
+
+    @Test
+    fun `foreslåVedtak - utførte og løsbare aksjonspunkter, ingen avbrutte`() {
+        val event = K9TilbakeEventDtoBuilder().foreslåVedtak().build()
+        val oppgaveDto = TilbakeEventTilOppgaveMapper.lagOppgaveDto(event, null)
+        val feltverdier = oppgaveDto.feltverdier
+
+        // FORESLÅ_VEDTAK (5004) er OPPRETTET og manuelt → løsbart
+        assertThat(verdierFor(feltverdier, "løsbartAksjonspunkt")).containsOnly(
+            AksjonspunktDefinisjonK9Tilbake.FORESLÅ_VEDTAK.kode
+        )
+
+        // VURDER_TILBAKEKREVING (5002), VURDER_FORELDELSE (5003), VENT_PÅ_BRUKERTILBAKEMELDING (7001), AVKLART_FAKTA_FEILUTBETALING (7003) er UTFØRT
+        assertThat(verdierFor(feltverdier, "utførtAksjonspunkt")).containsOnly(
+            AksjonspunktDefinisjonK9Tilbake.VURDER_TILBAKEKREVING.kode,
+            AksjonspunktDefinisjonK9Tilbake.VURDER_FORELDELSE.kode,
+            AksjonspunktDefinisjonK9Tilbake.VENT_PÅ_BRUKERTILBAKEMELDING.kode,
+            AksjonspunktDefinisjonK9Tilbake.AVKLART_FAKTA_FEILUTBETALING.kode,
+        )
+
+        // Ingen avbrutte
+        assertThat(verdierFor(feltverdier, "avbruttAksjonspunkt")).containsOnly(null)
+    }
+
+    @Test
+    fun `returFraBeslutter - utførte, avbrutte og løsbare aksjonspunkter`() {
+        val event = K9TilbakeEventDtoBuilder().returFraBeslutter().build()
+        val oppgaveDto = TilbakeEventTilOppgaveMapper.lagOppgaveDto(event, null)
+        val feltverdier = oppgaveDto.feltverdier
+
+        // FORESLÅ_VEDTAK (5004) er OPPRETTET og manuelt → løsbart
+        assertThat(verdierFor(feltverdier, "løsbartAksjonspunkt")).containsOnly(
+            AksjonspunktDefinisjonK9Tilbake.FORESLÅ_VEDTAK.kode
+        )
+
+        // VURDER_TILBAKEKREVING, VURDER_FORELDELSE, VENT_PÅ_BRUKERTILBAKEMELDING, AVKLART_FAKTA_FEILUTBETALING er UTFØRT
+        assertThat(verdierFor(feltverdier, "utførtAksjonspunkt")).containsOnly(
+            AksjonspunktDefinisjonK9Tilbake.VURDER_TILBAKEKREVING.kode,
+            AksjonspunktDefinisjonK9Tilbake.VURDER_FORELDELSE.kode,
+            AksjonspunktDefinisjonK9Tilbake.VENT_PÅ_BRUKERTILBAKEMELDING.kode,
+            AksjonspunktDefinisjonK9Tilbake.AVKLART_FAKTA_FEILUTBETALING.kode,
+        )
+
+        // FATTE_VEDTAK (5005) er AVBRUTT
+        assertThat(verdierFor(feltverdier, "avbruttAksjonspunkt")).containsOnly(
+            AksjonspunktDefinisjonK9Tilbake.FATTE_VEDTAK.kode
+        )
+    }
+
+    @Test
+    fun `avsluttet - alle aksjonspunkter utført, ingen avbrutte`() {
+        val event = K9TilbakeEventDtoBuilder().avsluttet().build()
+        val oppgaveDto = TilbakeEventTilOppgaveMapper.lagOppgaveDto(event, null)
+        val feltverdier = oppgaveDto.feltverdier
+
+        // Ingen OPPRETTET → løsbartAksjonspunkt er null
+        assertThat(verdierFor(feltverdier, "løsbartAksjonspunkt")).containsOnly(null)
+
+        // Alle er UTFØRT
+        assertThat(verdierFor(feltverdier, "utførtAksjonspunkt")).containsOnly(
+            AksjonspunktDefinisjonK9Tilbake.VURDER_TILBAKEKREVING.kode,
+            AksjonspunktDefinisjonK9Tilbake.VURDER_FORELDELSE.kode,
+            AksjonspunktDefinisjonK9Tilbake.FORESLÅ_VEDTAK.kode,
+            AksjonspunktDefinisjonK9Tilbake.FATTE_VEDTAK.kode,
+            AksjonspunktDefinisjonK9Tilbake.VENT_PÅ_BRUKERTILBAKEMELDING.kode,
+            AksjonspunktDefinisjonK9Tilbake.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG.kode,
+            AksjonspunktDefinisjonK9Tilbake.AVKLART_FAKTA_FEILUTBETALING.kode,
+        )
+
+        // Ingen avbrutte
+        assertThat(verdierFor(feltverdier, "avbruttAksjonspunkt")).containsOnly(null)
+    }
+
+    @Test
+    fun `hosBeslutter - FATTE_VEDTAK løsbart, resten utført`() {
+        val event = K9TilbakeEventDtoBuilder().hosBeslutter().build()
+        val oppgaveDto = TilbakeEventTilOppgaveMapper.lagOppgaveDto(event, null)
+        val feltverdier = oppgaveDto.feltverdier
+
+        // FATTE_VEDTAK (5005) er OPPRETTET og manuelt → løsbart
+        assertThat(verdierFor(feltverdier, "løsbartAksjonspunkt")).containsOnly(
+            AksjonspunktDefinisjonK9Tilbake.FATTE_VEDTAK.kode
+        )
+
+        // Resten er UTFØRT
+        assertThat(verdierFor(feltverdier, "utførtAksjonspunkt")).containsOnly(
+            AksjonspunktDefinisjonK9Tilbake.VURDER_TILBAKEKREVING.kode,
+            AksjonspunktDefinisjonK9Tilbake.VURDER_FORELDELSE.kode,
+            AksjonspunktDefinisjonK9Tilbake.FORESLÅ_VEDTAK.kode,
+            AksjonspunktDefinisjonK9Tilbake.VENT_PÅ_BRUKERTILBAKEMELDING.kode,
+            AksjonspunktDefinisjonK9Tilbake.AVKLART_FAKTA_FEILUTBETALING.kode,
+        )
+
+        // Ingen avbrutte
+        assertThat(verdierFor(feltverdier, "avbruttAksjonspunkt")).containsOnly(null)
+    }
+
+    @Test
+    fun `opprettet - VENT_PÅ_BRUKERTILBAKEMELDING utført, AVKLART_FAKTA løsbart`() {
+        val event = K9TilbakeEventDtoBuilder().opprettet().build()
+        val oppgaveDto = TilbakeEventTilOppgaveMapper.lagOppgaveDto(event, null)
+        val feltverdier = oppgaveDto.feltverdier
+
+        // AVKLART_FAKTA_FEILUTBETALING (7003) er OPPRETTET og er totrinn (ikke autopunkt) → løsbart
+        assertThat(verdierFor(feltverdier, "løsbartAksjonspunkt")).containsOnly(
+            AksjonspunktDefinisjonK9Tilbake.AVKLART_FAKTA_FEILUTBETALING.kode
+        )
+
+        // VENT_PÅ_BRUKERTILBAKEMELDING er UTFØRT
+        assertThat(verdierFor(feltverdier, "utførtAksjonspunkt")).containsOnly(
+            AksjonspunktDefinisjonK9Tilbake.VENT_PÅ_BRUKERTILBAKEMELDING.kode,
+        )
+
+        // Ingen avbrutte
+        assertThat(verdierFor(feltverdier, "avbruttAksjonspunkt")).containsOnly(null)
     }
 }


### PR DESCRIPTION
### Behov / Bakgrunn
Deler opp eksisterende aksjonspunkt-felter etter avbrutt/utført/fremtidig/løsbart. De eksisterende var sammenslått av flere kombinasjoner. Kan bruke gruppe til det i stedet for.

### Løsning
Nye felter som er skjulte. Utleder både gammelt og nytt nå. Planen er å fjerne de gamle gradvis.

### Andre endringer

