### PR TITLE
Chore/ytelse dvh sending 3

### DIFF
--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/eventmottak/kafka/KafkaAivenConfig.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/eventmottak/kafka/KafkaAivenConfig.kt
@@ -39,6 +39,7 @@ class KafkaAivenConfig(
 
     override fun producer(name: String) = properties.apply {
         put(ProducerConfig.CLIENT_ID_CONFIG, "$ID_PREFIX$name")
+        put(ProducerConfig.LINGER_MS_CONFIG, 100)
         put(ProducerConfig.BATCH_SIZE_CONFIG, 128 * 1024) // 128 KB
         put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "lz4")
     }

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/eventmottak/kafka/KafkaAivenConfig.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/eventmottak/kafka/KafkaAivenConfig.kt
@@ -39,7 +39,6 @@ class KafkaAivenConfig(
 
     override fun producer(name: String) = properties.apply {
         put(ProducerConfig.CLIENT_ID_CONFIG, "$ID_PREFIX$name")
-        put(ProducerConfig.LINGER_MS_CONFIG, 50)
         put(ProducerConfig.BATCH_SIZE_CONFIG, 128 * 1024) // 128 KB
         put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "lz4")
     }

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/statistikk/OppgavestatistikkTjeneste.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/statistikk/OppgavestatistikkTjeneste.kt
@@ -82,16 +82,16 @@ class OppgavestatistikkTjeneste(
         val kvitteringStats = TimingStats("kvittering")
         val totalPerOppgaveStats = TimingStats("total-per-oppgave")
         val kafkaFlushStats = TimingStats("kafka-flush")
+        val oppgaveIderTilKvittering = mutableListOf<Long>()
 
         oppgaverSomIkkeErSendt.forEachIndexed { index, oppgaveId ->
             val oppgaveStart = System.nanoTime()
-            sendStatistikkAsynkront(oppgaveId, pepCacheState, dbFetchStats, pepCacheStats, kvitteringStats)
+            sendStatistikkAsynkront(oppgaveId, pepCacheState, dbFetchStats, pepCacheStats)
+            oppgaveIderTilKvittering.add(oppgaveId)
             totalPerOppgaveStats.record(System.nanoTime() - oppgaveStart)
 
             if ((index + 1).mod(FLUSH_INTERVAL) == 0) {
-                val flushStart = System.nanoTime()
-                statistikkPublisher.flushOgValider()
-                kafkaFlushStats.record(System.nanoTime() - flushStart)
+                flushOgKvitter(oppgaveIderTilKvittering, kafkaFlushStats, kvitteringStats)
 
                 log.info("Sendt ${index + 1} eventer. Timing siste $FLUSH_INTERVAL: ${dbFetchStats.summary()}, ${pepCacheStats.summary()}, ${kvitteringStats.summary()}, ${totalPerOppgaveStats.summary()}, ${kafkaFlushStats.summary()}")
                 dbFetchStats.reset()
@@ -102,9 +102,7 @@ class OppgavestatistikkTjeneste(
             }
         }
         // Flush og logg resterende
-        val flushStart = System.nanoTime()
-        statistikkPublisher.flushOgValider()
-        kafkaFlushStats.record(System.nanoTime() - flushStart)
+        flushOgKvitter(oppgaveIderTilKvittering, kafkaFlushStats, kvitteringStats)
         if (oppgaverSomIkkeErSendt.size.mod(FLUSH_INTERVAL) != 0) {
             log.info("Siste batch timing: ${dbFetchStats.summary()}, ${pepCacheStats.summary()}, ${kvitteringStats.summary()}, ${totalPerOppgaveStats.summary()}, ${kafkaFlushStats.summary()}")
         }
@@ -123,7 +121,6 @@ class OppgavestatistikkTjeneste(
         pepCacheState: PepCachePerSaksnummerState,
         dbFetchStats: TimingStats,
         pepCacheStats: TimingStats,
-        kvitteringStats: TimingStats,
     ) {
         transactionalManager.transaction { tx ->
             val dbStart = System.nanoTime()
@@ -146,11 +143,24 @@ class OppgavestatistikkTjeneste(
                 }
                 statistikkPublisher.publiserAsynkront(sakTilSending, behandlingTilSending)
             }
+        }
+    }
 
+    private fun flushOgKvitter(
+        oppgaveIderTilKvittering: MutableList<Long>,
+        kafkaFlushStats: TimingStats,
+        kvitteringStats: TimingStats,
+    ) {
+        val flushStart = System.nanoTime()
+        statistikkPublisher.flushOgValider()
+        kafkaFlushStats.record(System.nanoTime() - flushStart)
+
+        oppgaveIderTilKvittering.forEach { oppgaveId ->
             val kvitteringStart = System.nanoTime()
-            statistikkRepository.kvitterSending(tx, oppgaveId)
+            statistikkRepository.kvitterSending(oppgaveId)
             kvitteringStats.record(System.nanoTime() - kvitteringStart)
         }
+        oppgaveIderTilKvittering.clear()
     }
 
     private fun nullUtEventuelleSensitiveFelter(sak: Sak): Sak {

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/statistikk/OppgavestatistikkTjeneste.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/statistikk/OppgavestatistikkTjeneste.kt
@@ -47,18 +47,57 @@ class OppgavestatistikkTjeneste(
     private val k9SakMapper = K9SakOppgaveTilDVHMapper()
     private val k9KlageMapper = K9KlageOppgaveTilDVHMapper()
 
+    private class TimingStats(val name: String) {
+        private val samples = mutableListOf<Long>()
+
+        fun record(nanos: Long) { samples.add(nanos) }
+
+        fun summary(): String {
+            if (samples.isEmpty()) return "$name: ingen målinger"
+            val sortert = samples.sorted()
+            val min = sortert.first() / 1_000_000
+            val max = sortert.last() / 1_000_000
+            val avg = (sortert.sum() / sortert.size) / 1_000_000
+            val p50 = sortert[sortert.size / 2] / 1_000_000
+            val p95 = sortert[(sortert.size * 0.95).toInt().coerceAtMost(sortert.size - 1)] / 1_000_000
+            return "$name: min=${min}ms avg=${avg}ms p50=${p50}ms p95=${p95}ms max=${max}ms (n=${sortert.size})"
+        }
+
+        fun reset() { samples.clear() }
+    }
+
     fun spillAvUsendtStatistikk() {
         log.info("Starter sending av saks- og behandlingsstatistikk til DVH")
         val tidStatistikksendingStartet = System.currentTimeMillis()
         val oppgaverSomIkkeErSendt = statistikkRepository.hentOppgaverSomIkkeErSendt()
         val pepCacheState = PepCachePerSaksnummerState(pepCacheRepository)
         log.info("Fant ${oppgaverSomIkkeErSendt.size} oppgaveversjoner som ikke er sendt til DVH")
+
+        val dbFetchStats = TimingStats("db-fetch")
+        val pepCacheStats = TimingStats("pep-cache")
+        val kafkaSendStats = TimingStats("kafka-send")
+        val kvitteringStats = TimingStats("kvittering")
+        val totalPerOppgaveStats = TimingStats("total-per-oppgave")
+
         oppgaverSomIkkeErSendt.forEachIndexed { index, oppgaveId ->
-            sendStatistikk(oppgaveId, pepCacheState)
-            if (index.mod(100) == 0) {
-                log.info("Sendt $index eventer")
+            val oppgaveStart = System.nanoTime()
+            sendStatistikk(oppgaveId, pepCacheState, dbFetchStats, pepCacheStats, kafkaSendStats, kvitteringStats)
+            totalPerOppgaveStats.record(System.nanoTime() - oppgaveStart)
+
+            if ((index + 1).mod(100) == 0) {
+                log.info("Sendt ${index + 1} eventer. Timing siste 100: ${dbFetchStats.summary()}, ${pepCacheStats.summary()}, ${kafkaSendStats.summary()}, ${kvitteringStats.summary()}, ${totalPerOppgaveStats.summary()}")
+                dbFetchStats.reset()
+                pepCacheStats.reset()
+                kafkaSendStats.reset()
+                kvitteringStats.reset()
+                totalPerOppgaveStats.reset()
             }
         }
+        // Logg resterende
+        if (oppgaverSomIkkeErSendt.size.mod(100) != 0) {
+            log.info("Siste batch timing: ${dbFetchStats.summary()}, ${pepCacheStats.summary()}, ${kafkaSendStats.summary()}, ${kvitteringStats.summary()}, ${totalPerOppgaveStats.summary()}")
+        }
+
         val tidStatistikksendingFerdig = System.currentTimeMillis()
         val kjoretid = tidStatistikksendingFerdig - tidStatistikksendingStartet
         log.info("Sending av saks- og behanlingsstatistikk ferdig")
@@ -72,29 +111,50 @@ class OppgavestatistikkTjeneste(
     private fun sendStatistikk(
         @SpanAttribute oppgaveId: Long,
         pepCacheState: PepCachePerSaksnummerState,
+        dbFetchStats: TimingStats,
+        pepCacheStats: TimingStats,
+        kafkaSendStats: TimingStats,
+        kvitteringStats: TimingStats,
     ) {
         transactionalManager.transaction { tx ->
-            sendStatistikk(oppgaveId, tx, pepCacheState)
+            val kafkaNanos = sendStatistikk(oppgaveId, tx, pepCacheState, dbFetchStats, pepCacheStats)
+            kafkaSendStats.record(kafkaNanos)
+
+            val kvitteringStart = System.nanoTime()
             statistikkRepository.kvitterSending(tx, oppgaveId)
+            kvitteringStats.record(System.nanoTime() - kvitteringStart)
         }
     }
 
-    private fun sendStatistikk(id: Long, tx: TransactionalSession, pepCacheState: PepCachePerSaksnummerState) {
+    private fun sendStatistikk(
+        id: Long,
+        tx: TransactionalSession,
+        pepCacheState: PepCachePerSaksnummerState,
+        dbFetchStats: TimingStats,
+        pepCacheStats: TimingStats,
+    ): Long {
+        val dbStart = System.nanoTime()
         val oppgavestatistikkgrunnlag = byggOppgavestatistikk(id, tx)
+        dbFetchStats.record(System.nanoTime() - dbStart)
+
+        val pepStart = System.nanoTime()
         val erKode6 = pepCacheState.hentEllerOppdater(
             saksnummer = oppgavestatistikkgrunnlag.sak.saksnummer,
             oppgaveEksternId = oppgavestatistikkgrunnlag.oppgaveEksternId,
             tx = tx,
         )
+        pepCacheStats.record(System.nanoTime() - pepStart)
 
         val sakTilSending = if (erKode6) nullUtEventuelleSensitiveFelter(oppgavestatistikkgrunnlag.sak) else oppgavestatistikkgrunnlag.sak
+        var totalKafkaNanos = 0L
         oppgavestatistikkgrunnlag.behandlinger.forEach {
             val behandlingTilSending = if (erKode6) nullUtEventuelleSensitiveFelter(it) else it
             if (log.isDebugEnabled) {
                 log.debug("Utgående DvhBehandling: {}", behandlingTilSending.tryggToString())
             }
-            statistikkPublisher.publiser(sakTilSending, behandlingTilSending)
+            totalKafkaNanos += statistikkPublisher.publiser(sakTilSending, behandlingTilSending)
         }
+        return totalKafkaNanos
     }
 
     private fun nullUtEventuelleSensitiveFelter(sak: Sak): Sak {

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/statistikk/OppgavestatistikkTjeneste.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/statistikk/OppgavestatistikkTjeneste.kt
@@ -66,6 +66,10 @@ class OppgavestatistikkTjeneste(
         fun reset() { samples.clear() }
     }
 
+    companion object {
+        private const val FLUSH_INTERVAL = 100
+    }
+
     fun spillAvUsendtStatistikk() {
         log.info("Starter sending av saks- og behandlingsstatistikk til DVH")
         val tidStatistikksendingStartet = System.currentTimeMillis()
@@ -75,86 +79,78 @@ class OppgavestatistikkTjeneste(
 
         val dbFetchStats = TimingStats("db-fetch")
         val pepCacheStats = TimingStats("pep-cache")
-        val kafkaSendStats = TimingStats("kafka-send")
         val kvitteringStats = TimingStats("kvittering")
         val totalPerOppgaveStats = TimingStats("total-per-oppgave")
+        val kafkaFlushStats = TimingStats("kafka-flush")
 
         oppgaverSomIkkeErSendt.forEachIndexed { index, oppgaveId ->
             val oppgaveStart = System.nanoTime()
-            sendStatistikk(oppgaveId, pepCacheState, dbFetchStats, pepCacheStats, kafkaSendStats, kvitteringStats)
+            sendStatistikkAsynkront(oppgaveId, pepCacheState, dbFetchStats, pepCacheStats, kvitteringStats)
             totalPerOppgaveStats.record(System.nanoTime() - oppgaveStart)
 
-            if ((index + 1).mod(100) == 0) {
-                log.info("Sendt ${index + 1} eventer. Timing siste 100: ${dbFetchStats.summary()}, ${pepCacheStats.summary()}, ${kafkaSendStats.summary()}, ${kvitteringStats.summary()}, ${totalPerOppgaveStats.summary()}")
+            if ((index + 1).mod(FLUSH_INTERVAL) == 0) {
+                val flushStart = System.nanoTime()
+                statistikkPublisher.flushOgValider()
+                kafkaFlushStats.record(System.nanoTime() - flushStart)
+
+                log.info("Sendt ${index + 1} eventer. Timing siste $FLUSH_INTERVAL: ${dbFetchStats.summary()}, ${pepCacheStats.summary()}, ${kvitteringStats.summary()}, ${totalPerOppgaveStats.summary()}, ${kafkaFlushStats.summary()}")
                 dbFetchStats.reset()
                 pepCacheStats.reset()
-                kafkaSendStats.reset()
                 kvitteringStats.reset()
                 totalPerOppgaveStats.reset()
+                kafkaFlushStats.reset()
             }
         }
-        // Logg resterende
-        if (oppgaverSomIkkeErSendt.size.mod(100) != 0) {
-            log.info("Siste batch timing: ${dbFetchStats.summary()}, ${pepCacheStats.summary()}, ${kafkaSendStats.summary()}, ${kvitteringStats.summary()}, ${totalPerOppgaveStats.summary()}")
+        // Flush og logg resterende
+        val flushStart = System.nanoTime()
+        statistikkPublisher.flushOgValider()
+        kafkaFlushStats.record(System.nanoTime() - flushStart)
+        if (oppgaverSomIkkeErSendt.size.mod(FLUSH_INTERVAL) != 0) {
+            log.info("Siste batch timing: ${dbFetchStats.summary()}, ${pepCacheStats.summary()}, ${kvitteringStats.summary()}, ${totalPerOppgaveStats.summary()}, ${kafkaFlushStats.summary()}")
         }
 
-        val tidStatistikksendingFerdig = System.currentTimeMillis()
-        val kjoretid = tidStatistikksendingFerdig - tidStatistikksendingStartet
-        log.info("Sending av saks- og behanlingsstatistikk ferdig")
-        log.info("Sendt ${oppgaverSomIkkeErSendt.size} oppgaversjoner. Totalt tidsbruk: ${kjoretid} ms")
+        val kjoretid = System.currentTimeMillis() - tidStatistikksendingStartet
+        log.info("Sending av saks- og behandlingsstatistikk ferdig")
+        log.info("Sendt ${oppgaverSomIkkeErSendt.size} oppgaveversjoner. Totalt tidsbruk: ${kjoretid} ms")
         if (oppgaverSomIkkeErSendt.isNotEmpty()) {
             log.info("Gjennomsnitt tidsbruk: ${kjoretid / oppgaverSomIkkeErSendt.size} ms pr oppgaveversjon")
         }
     }
 
     @WithSpan
-    private fun sendStatistikk(
+    private fun sendStatistikkAsynkront(
         @SpanAttribute oppgaveId: Long,
         pepCacheState: PepCachePerSaksnummerState,
         dbFetchStats: TimingStats,
         pepCacheStats: TimingStats,
-        kafkaSendStats: TimingStats,
         kvitteringStats: TimingStats,
     ) {
         transactionalManager.transaction { tx ->
-            val kafkaNanos = sendStatistikk(oppgaveId, tx, pepCacheState, dbFetchStats, pepCacheStats)
-            kafkaSendStats.record(kafkaNanos)
+            val dbStart = System.nanoTime()
+            val oppgavestatistikkgrunnlag = byggOppgavestatistikk(oppgaveId, tx)
+            dbFetchStats.record(System.nanoTime() - dbStart)
+
+            val pepStart = System.nanoTime()
+            val erKode6 = pepCacheState.hentEllerOppdater(
+                saksnummer = oppgavestatistikkgrunnlag.sak.saksnummer,
+                oppgaveEksternId = oppgavestatistikkgrunnlag.oppgaveEksternId,
+                tx = tx,
+            )
+            pepCacheStats.record(System.nanoTime() - pepStart)
+
+            val sakTilSending = if (erKode6) nullUtEventuelleSensitiveFelter(oppgavestatistikkgrunnlag.sak) else oppgavestatistikkgrunnlag.sak
+            oppgavestatistikkgrunnlag.behandlinger.forEach {
+                val behandlingTilSending = if (erKode6) nullUtEventuelleSensitiveFelter(it) else it
+                if (log.isDebugEnabled) {
+                    log.debug("Utgående DvhBehandling: {}", behandlingTilSending.tryggToString())
+                }
+                statistikkPublisher.publiserAsynkront(sakTilSending, behandlingTilSending)
+            }
 
             val kvitteringStart = System.nanoTime()
             statistikkRepository.kvitterSending(tx, oppgaveId)
             kvitteringStats.record(System.nanoTime() - kvitteringStart)
         }
-    }
-
-    private fun sendStatistikk(
-        id: Long,
-        tx: TransactionalSession,
-        pepCacheState: PepCachePerSaksnummerState,
-        dbFetchStats: TimingStats,
-        pepCacheStats: TimingStats,
-    ): Long {
-        val dbStart = System.nanoTime()
-        val oppgavestatistikkgrunnlag = byggOppgavestatistikk(id, tx)
-        dbFetchStats.record(System.nanoTime() - dbStart)
-
-        val pepStart = System.nanoTime()
-        val erKode6 = pepCacheState.hentEllerOppdater(
-            saksnummer = oppgavestatistikkgrunnlag.sak.saksnummer,
-            oppgaveEksternId = oppgavestatistikkgrunnlag.oppgaveEksternId,
-            tx = tx,
-        )
-        pepCacheStats.record(System.nanoTime() - pepStart)
-
-        val sakTilSending = if (erKode6) nullUtEventuelleSensitiveFelter(oppgavestatistikkgrunnlag.sak) else oppgavestatistikkgrunnlag.sak
-        var totalKafkaNanos = 0L
-        oppgavestatistikkgrunnlag.behandlinger.forEach {
-            val behandlingTilSending = if (erKode6) nullUtEventuelleSensitiveFelter(it) else it
-            if (log.isDebugEnabled) {
-                log.debug("Utgående DvhBehandling: {}", behandlingTilSending.tryggToString())
-            }
-            totalKafkaNanos += statistikkPublisher.publiser(sakTilSending, behandlingTilSending)
-        }
-        return totalKafkaNanos
     }
 
     private fun nullUtEventuelleSensitiveFelter(sak: Sak): Sak {

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/statistikk/StatistikkPublisher.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/statistikk/StatistikkPublisher.kt
@@ -14,6 +14,7 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.StringSerializer
 import org.json.JSONObject
 import org.slf4j.LoggerFactory
+import java.util.concurrent.atomic.AtomicReference
 
 class StatistikkPublisher(
     val kafkaConfig: IKafkaConfig,
@@ -49,6 +50,38 @@ class StatistikkPublisher(
         return sakNanos + behandlingNanos
     }
 
+    private val asyncError = AtomicReference<Exception>(null)
+
+    /**
+     * Legger meldinger i producer-bufferen uten å blokkere.
+     * Kall [flushOgValider] periodisk for å sikre levering og oppdage feil.
+     */
+    fun publiserAsynkront(sak: Sak, behandling: Behandling) {
+        sendAsync(sak, sak.saksnummer, TOPIC_USE_STATISTIKK_SAK.name)
+        sendAsync(behandling, behandling.behandlingId, TOPIC_USE_STATISTIKK_BEHANDLING.name)
+    }
+
+    /**
+     * Blokkerer til alle buffrede meldinger er sendt og bekreftet.
+     * Kaster exception hvis noen av de asynkrone sendingene feilet.
+     */
+    fun flushOgValider() {
+        producer.flush()
+        val feil = asyncError.getAndSet(null)
+        if (feil != null) {
+            throw feil
+        }
+    }
+
+    private fun sendAsync(melding: Any, key: String, topic: String) {
+        val meldingJson = LosObjectMapper.instance.writeValueAsString(melding)
+        producer.send(ProducerRecord(topic, key, meldingJson)) { _, exception ->
+            if (exception != null) {
+                log.error("Feil ved asynkron sending til Kafka topic $topic", exception)
+                asyncError.compareAndSet(null, exception)
+            }
+        }
+    }
 
     private fun send(melding: Any, key: String, topic: String): Long {
         val meldingJson = LosObjectMapper.instance.writeValueAsString(melding)

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/statistikk/StatistikkPublisher.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/statistikk/StatistikkPublisher.kt
@@ -43,13 +43,6 @@ class StatistikkPublisher(
         StringSerializer()
     )
 
-    /** @return total Kafka send time in nanoseconds (sak + behandling) */
-    fun publiser(sak: Sak, behandling: Behandling): Long {
-        val sakNanos = send(sak, sak.saksnummer, TOPIC_USE_STATISTIKK_SAK.name)
-        val behandlingNanos = send(behandling, behandling.behandlingId, TOPIC_USE_STATISTIKK_BEHANDLING.name)
-        return sakNanos + behandlingNanos
-    }
-
     private val asyncError = AtomicReference<Exception>(null)
 
     /**
@@ -81,17 +74,6 @@ class StatistikkPublisher(
                 asyncError.compareAndSet(null, exception)
             }
         }
-    }
-
-    private fun send(melding: Any, key: String, topic: String): Long {
-        val meldingJson = LosObjectMapper.instance.writeValueAsString(melding)
-        val startNanos = System.nanoTime()
-        producer.send(ProducerRecord(topic, key, meldingJson)) { _, exception ->
-            if (exception != null) {
-                log.error("", exception)
-            }
-        }.get()
-        return System.nanoTime() - startNanos
     }
 
     internal fun stop() = producer.close()

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/statistikk/StatistikkPublisher.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/statistikk/StatistikkPublisher.kt
@@ -42,30 +42,23 @@ class StatistikkPublisher(
         StringSerializer()
     )
 
-    fun publiser(sak: Sak, behandling: Behandling) {
-        /*
-        if (config.koinProfile() == KoinProfile.LOCAL) {
-            return
-        }
-        */
-        send(sak, sak.saksnummer, TOPIC_USE_STATISTIKK_SAK.name)
-        send(behandling, behandling.behandlingId, TOPIC_USE_STATISTIKK_BEHANDLING.name)
+    /** @return total Kafka send time in nanoseconds (sak + behandling) */
+    fun publiser(sak: Sak, behandling: Behandling): Long {
+        val sakNanos = send(sak, sak.saksnummer, TOPIC_USE_STATISTIKK_SAK.name)
+        val behandlingNanos = send(behandling, behandling.behandlingId, TOPIC_USE_STATISTIKK_BEHANDLING.name)
+        return sakNanos + behandlingNanos
     }
 
 
-    private fun send(melding: Any, key: String, topic: String) {
-        /*if (config.koinProfile() == KoinProfile.LOCAL) {
-            log.info("Lokal kjøring, sender ikke melding til statistikk")
-            return
-        }
-*/
-        val publiserStatistikk = System.currentTimeMillis()
+    private fun send(melding: Any, key: String, topic: String): Long {
         val meldingJson = LosObjectMapper.instance.writeValueAsString(melding)
+        val startNanos = System.nanoTime()
         producer.send(ProducerRecord(topic, key, meldingJson)) { _, exception ->
             if (exception != null) {
                 log.error("", exception)
             }
         }.get()
+        return System.nanoTime() - startNanos
     }
 
     internal fun stop() = producer.close()

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/statistikk/StatistikkPublisher.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/statistikk/StatistikkPublisher.kt
@@ -77,7 +77,7 @@ class StatistikkPublisher(
         val meldingJson = LosObjectMapper.instance.writeValueAsString(melding)
         producer.send(ProducerRecord(topic, key, meldingJson)) { _, exception ->
             if (exception != null) {
-                log.error("Feil ved asynkron sending til Kafka topic $topic", exception)
+                log.error("Feil ved asynkron sending til Kafka topic={} key={}", topic, key, exception)
                 asyncError.compareAndSet(null, exception)
             }
         }


### PR DESCRIPTION
### Behov / Bakgrunn

Forbedre ytelsen ved sending av DVH-statistikk, samtidig som leveringen fortsatt er robust og feilsøkbar.

### Løsning

DVH-statistikk sendes asynkront til Kafka med periodisk `flush()` i batcher i stedet for synkron `send(...).get()` per melding.

I tillegg er løsningen justert etter tilbakemeldinger:
- `kvitterSending` skjer først etter vellykket `flushOgValider()`, slik at oppgaver ikke markeres som sendt før Kafka-levering er bekreftet
- async-feil logges med både topic og key for bedre feilsøking
- ubrukt synkront publiserings-API og tilhørende privat `send`-hjelper er fjernet
- timingmålinger per fase beholdes for å følge med på db-oppslag, pep-cache, kvittering, total tid per oppgave og kafka-flush
- `linger.ms` er satt til 100 for producer-konfigurasjonen som brukes i LOS

### Andre endringer

Mergekonflikter mot `master` er løst uten å endre den tilsiktede DVH-løsningen i PR-en.