### PR TITLE
PepCacheService mot partisjonert tabell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ buildNumber.properties
 
 # Maven local settings (contains credentials)
 settings.xml
+
+.DS_Store

--- a/src/main/kotlin/no/nav/k9/los/KoinProfiles.kt
+++ b/src/main/kotlin/no/nav/k9/los/KoinProfiles.kt
@@ -499,7 +499,6 @@ fun common(app: Application, config: Configuration) = module {
         PepCacheService(
             pepClient = get(),
             pepCacheRepository = get(),
-            oppgaveRepository = get(),
             transactionalManager = get()
         )
     }

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/eventtiloppgave/OppgaveOppdatertHandler.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/domeneadaptere/k9/eventtiloppgave/OppgaveOppdatertHandler.kt
@@ -1,11 +1,13 @@
 package no.nav.k9.los.nyoppgavestyring.domeneadaptere.k9.eventtiloppgave
 
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.runBlocking
 import kotliquery.TransactionalSession
 import no.nav.k9.kodeverk.behandling.aksjonspunkt.AksjonspunktDefinisjon
 import no.nav.k9.los.nyoppgavestyring.domeneadaptere.k9.eventmottak.eventlager.EventLagret
 import no.nav.k9.los.nyoppgavestyring.domeneadaptere.k9.eventmottak.tilbakekrav.AksjonspunktDefinisjonK9Tilbake
+import no.nav.k9.los.nyoppgavestyring.infrastruktur.abac.cache.PepCacheInput
 import no.nav.k9.los.nyoppgavestyring.infrastruktur.abac.cache.PepCacheService
 import no.nav.k9.los.nyoppgavestyring.ko.KøpåvirkendeHendelse
 import no.nav.k9.los.nyoppgavestyring.ko.OppgaveHendelseMottatt
@@ -29,7 +31,20 @@ class OppgaveOppdatertHandler(
     private val log: Logger = LoggerFactory.getLogger(OppgaveOppdatertHandler::class.java)
 
     internal fun oppdaterPepCache(oppgave: OppgaveV3, tx: TransactionalSession) {
-        pepCacheService.oppdater(tx, oppgave.kildeområde, oppgave.eksternId)
+        runBlocking(Dispatchers.IO) {
+            pepCacheService.oppdater(
+                tx,
+                PepCacheInput(
+                    oppgave.eksternId,
+                    oppgave.hentVerdi("saksnummer"),
+                    listOfNotNull(
+                        oppgave.hentVerdi("aktorId"),
+                        oppgave.hentVerdi("pleietrengendeAktorId"),
+                        oppgave.hentVerdi("relatertPartAktorid")
+                    )
+                )
+            )
+        }
     }
 
     internal fun håndterOppgaveOppdatert(

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/infrastruktur/abac/cache/PepCacheRepository.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/infrastruktur/abac/cache/PepCacheRepository.kt
@@ -27,7 +27,7 @@ class PepCacheRepository(
                     (select ov.verdi from oppgavefelt_verdi_part ov where ov.oppgave_id = o.id AND ov.feltdefinisjon_ekstern_id = 'pleietrengendeAktorId' AND ov.oppgavestatus IN ($statusParametre)) as pleietrengende_aktor_id,
                     (select ov.verdi from oppgavefelt_verdi_part ov where ov.oppgave_id = o.id AND ov.feltdefinisjon_ekstern_id = 'relatertPartAktorid' AND ov.oppgavestatus IN ($statusParametre)) as relatert_part_aktor_id
                     FROM oppgave_v3_part o 
-                    LEFT JOIN OPPGAVE_PEP_CACHE opc ON o.oppgave_ekstern_id = opc.ekstern_id
+                    LEFT JOIN OPPGAVE_PEP_CACHE opc ON (o.oppgave_ekstern_id = opc.ekstern_id AND opc.kildeomrade = 'K9')
                     WHERE o.oppgavestatus IN ($statusParametre)
                     AND (opc.oppdatert is null OR opc.oppdatert < :grense)
                     ORDER BY opc.oppdatert NULLS FIRST

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/infrastruktur/abac/cache/PepCacheRepository.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/infrastruktur/abac/cache/PepCacheRepository.kt
@@ -5,13 +5,55 @@ import kotliquery.Row
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
 import kotliquery.sessionOf
-import java.time.Duration
+import no.nav.k9.los.nyoppgavestyring.infrastruktur.db.util.InClauseHjelper
+import no.nav.k9.los.nyoppgavestyring.mottak.oppgave.Oppgavestatus
 import java.time.LocalDateTime
 import javax.sql.DataSource
 
 class PepCacheRepository(
     val dataSource: DataSource
 ) {
+    fun hentOppgaverMedStatusOgPepCacheEldreEnn(
+        tidspunkt: LocalDateTime = LocalDateTime.now(),
+        antall: Int = 1,
+        status: Set<Oppgavestatus>,
+        tx: TransactionalSession
+    ): List<PepCacheInput> {
+        val statusParametre = InClauseHjelper.tilParameternavn(status, "status")
+        val query = """
+                    SELECT o.oppgave_ekstern_id, 
+                    (select ov.verdi from oppgavefelt_verdi_part ov where ov.oppgave_id = o.id AND ov.feltdefinisjon_ekstern_id = 'saksnummer' AND ov.oppgavestatus IN ($statusParametre)) as saksnummer,
+                    (select ov.verdi from oppgavefelt_verdi_part ov where ov.oppgave_id = o.id AND ov.feltdefinisjon_ekstern_id = 'aktorId' AND ov.oppgavestatus IN ($statusParametre)) as aktor_id,
+                    (select ov.verdi from oppgavefelt_verdi_part ov where ov.oppgave_id = o.id AND ov.feltdefinisjon_ekstern_id = 'pleietrengendeAktorId' AND ov.oppgavestatus IN ($statusParametre)) as pleietrengende_aktor_id,
+                    (select ov.verdi from oppgavefelt_verdi_part ov where ov.oppgave_id = o.id AND ov.feltdefinisjon_ekstern_id = 'relatertPartAktorid' AND ov.oppgavestatus IN ($statusParametre)) as relatert_part_aktor_id
+                    FROM oppgave_v3_part o 
+                    LEFT JOIN OPPGAVE_PEP_CACHE opc ON o.oppgave_ekstern_id = opc.ekstern_id
+                    WHERE o.oppgavestatus IN ($statusParametre)
+                    AND (opc.oppdatert is null OR opc.oppdatert < :grense)
+                    ORDER BY opc.oppdatert NULLS FIRST
+                    LIMIT :limit
+                """.trimIndent()
+        return tx.run(
+            queryOf(
+                query,
+                buildMap {
+                    put("grense", tidspunkt)
+                    put("limit", antall)
+                    putAll(InClauseHjelper.parameternavnTilVerdierMap(status.map { it.kode }, "status"))
+                }
+            ).map { row ->
+                PepCacheInput(
+                    row.string("oppgave_ekstern_id"),
+                    row.stringOrNull("saksnummer"),
+                    listOfNotNull(
+                        row.stringOrNull("aktor_id"),
+                        row.stringOrNull("pleietrengende_aktor_id"),
+                        row.stringOrNull("relatert_part_aktor_id")
+                    )
+                )
+            }.asList
+        )
+    }
 
     fun lagre(cache: PepCache, tx: TransactionalSession) {
         tx.run(

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/infrastruktur/abac/cache/PepCacheRepository.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/infrastruktur/abac/cache/PepCacheRepository.kt
@@ -87,10 +87,6 @@ data class PepCache(
     val egenAnsatt: Boolean,
     val oppdatert: LocalDateTime
 ) {
-    fun erGyldig(maksimalAlder: Duration): Boolean {
-        return oppdatert < (LocalDateTime.now() - maksimalAlder)
-    }
-
     fun oppdater(kode6: Boolean, kode7: Boolean, egenAnsatt: Boolean): PepCache {
         return copy(
             kode6 = kode6,
@@ -98,9 +94,5 @@ data class PepCache(
             egenAnsatt = egenAnsatt,
             oppdatert = LocalDateTime.now()
         )
-    }
-
-    fun måSjekkes(): Boolean {
-        return kode6 || kode7 || egenAnsatt
     }
 }

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/infrastruktur/abac/cache/PepCacheService.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/infrastruktur/abac/cache/PepCacheService.kt
@@ -33,8 +33,8 @@ class PepCacheService(
             runBlocking(Dispatchers.IO) {
                 val oppgaverSomMåOppdateres = hentOppgaverMedStatusOgPepCacheEldreEnn(
                     tidspunkt = LocalDateTime.now() - gyldighet,
-                    status = status,
                     antall = 1,
+                    status = status,
                     tx
                 )
                 oppgaverSomMåOppdateres.forEach { oppgave -> oppdater(tx, oppgave) }
@@ -44,8 +44,8 @@ class PepCacheService(
 
     private fun hentOppgaverMedStatusOgPepCacheEldreEnn(
         tidspunkt: LocalDateTime = LocalDateTime.now(),
-        status: Set<Oppgavestatus>,
         antall: Int = 1,
+        status: Set<Oppgavestatus>,
         tx: TransactionalSession
     ): List<PepCacheInput> {
         val statusParametre = InClauseHjelper.tilParameternavn(status, "status")

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/infrastruktur/abac/cache/PepCacheService.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/infrastruktur/abac/cache/PepCacheService.kt
@@ -3,16 +3,13 @@ package no.nav.k9.los.nyoppgavestyring.infrastruktur.abac.cache
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.extension.kotlin.asContextElement
 import io.opentelemetry.instrumentation.annotations.WithSpan
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.*
 import kotliquery.TransactionalSession
+import kotliquery.queryOf
 import no.nav.k9.los.nyoppgavestyring.infrastruktur.abac.IPepClient
 import no.nav.k9.los.nyoppgavestyring.infrastruktur.db.TransactionalManager
+import no.nav.k9.los.nyoppgavestyring.infrastruktur.db.util.InClauseHjelper
 import no.nav.k9.los.nyoppgavestyring.mottak.oppgave.Oppgavestatus
-import no.nav.k9.los.nyoppgavestyring.visningoguttrekk.Oppgave
-import no.nav.k9.los.nyoppgavestyring.visningoguttrekk.OppgaveRepository
 import no.nav.sif.abac.kontrakt.abac.Diskresjonskode
 import java.time.Duration
 import java.time.LocalDateTime
@@ -20,7 +17,6 @@ import java.time.LocalDateTime
 class PepCacheService(
     private val pepClient: IPepClient,
     private val pepCacheRepository: PepCacheRepository,
-    private val oppgaveRepository: OppgaveRepository,
     private val transactionalManager: TransactionalManager
 ) {
 
@@ -35,10 +31,10 @@ class PepCacheService(
     ) {
         transactionalManager.transaction { tx ->
             runBlocking(Dispatchers.IO) {
-                val oppgaverSomMåOppdateres = oppgaveRepository.hentOppgaverMedStatusOgPepCacheEldreEnn(
+                val oppgaverSomMåOppdateres = hentOppgaverMedStatusOgPepCacheEldreEnn(
                     tidspunkt = LocalDateTime.now() - gyldighet,
-                    antall = 1,
                     status = status,
+                    antall = 1,
                     tx
                 )
                 oppgaverSomMåOppdateres.forEach { oppgave -> oppdater(tx, oppgave) }
@@ -46,24 +42,55 @@ class PepCacheService(
         }
     }
 
-    fun oppdater(tx: TransactionalSession, kildeområde: String, eksternId: String): PepCache {
-        return runBlocking(Dispatchers.IO) {
-            val oppgave = oppgaveRepository.hentNyesteOppgaveForEksternId(
-                tx,
-                kildeområde = kildeområde,
-                eksternId = eksternId
-            )
-            oppdater(tx, oppgave)
-        }
+    private fun hentOppgaverMedStatusOgPepCacheEldreEnn(
+        tidspunkt: LocalDateTime = LocalDateTime.now(),
+        status: Set<Oppgavestatus>,
+        antall: Int = 1,
+        tx: TransactionalSession
+    ): List<PepCacheInput> {
+        val statusParametre = InClauseHjelper.tilParameternavn(status, "status")
+        val query = """
+                    SELECT o.oppgave_ekstern_id, 
+                    (select ov.verdi from oppgavefelt_verdi_part ov where ov.oppgave_id = o.id AND ov.feltdefinisjon_ekstern_id = 'saksnummer' AND ov.oppgavestatus IN ($statusParametre)) as saksnummer,
+                    (select ov.verdi from oppgavefelt_verdi_part ov where ov.oppgave_id = o.id AND ov.feltdefinisjon_ekstern_id = 'aktorId' AND ov.oppgavestatus IN ($statusParametre)) as aktor_id,
+                    (select ov.verdi from oppgavefelt_verdi_part ov where ov.oppgave_id = o.id AND ov.feltdefinisjon_ekstern_id = 'pleietrengendeAktorId' AND ov.oppgavestatus IN ($statusParametre)) as pleietrengende_aktor_id,
+                    (select ov.verdi from oppgavefelt_verdi_part ov where ov.oppgave_id = o.id AND ov.feltdefinisjon_ekstern_id = 'relatertPartAktorid' AND ov.oppgavestatus IN ($statusParametre)) as relatert_part_aktor_id
+                    FROM oppgave_v3_part o 
+                    LEFT JOIN OPPGAVE_PEP_CACHE opc ON o.oppgave_ekstern_id = opc.ekstern_id
+                    WHERE o.oppgavestatus IN ($statusParametre)
+                    AND (opc.oppdatert is null OR opc.oppdatert < :grense)
+                    ORDER BY opc.oppdatert NULLS FIRST
+                    LIMIT :limit
+                """.trimIndent()
+        return tx.run(
+            queryOf(
+                query,
+                buildMap {
+                    put("grense", tidspunkt)
+                    put("limit", antall)
+                    putAll(InClauseHjelper.parameternavnTilVerdierMap(status.map { it.kode }, "status"))
+                }
+            ).map { row ->
+                PepCacheInput(
+                    row.string("oppgave_ekstern_id"),
+                    row.stringOrNull("saksnummer"),
+                    listOfNotNull(
+                        row.stringOrNull("aktor_id"),
+                        row.stringOrNull("pleietrengende_aktor_id"),
+                        row.stringOrNull("relatert_part_aktor_id")
+                    )
+                )
+            }.asList
+        )
     }
 
-    suspend fun oppdater(tx: TransactionalSession, oppgave: Oppgave): PepCache {
+    suspend fun oppdater(tx: TransactionalSession, oppgave: PepCacheInput): PepCache {
         return lagPepCacheFra(oppgave).also { nyPepCache -> pepCacheRepository.lagre(nyPepCache, tx) }
     }
 
-    private suspend fun lagPepCacheFra(oppgave: Oppgave): PepCache {
+    private suspend fun lagPepCacheFra(oppgaveIdOgAktører: PepCacheInput): PepCache {
         val pep = PepCache(
-            eksternId = oppgave.eksternId,
+            eksternId = oppgaveIdOgAktører.eksternId,
             kildeområde = "K9",
             kode6 = false,
             kode7 = false,
@@ -71,12 +98,10 @@ class PepCacheService(
             oppdatert = LocalDateTime.now()
         )
 
-        val saksnummer = oppgave.hentVerdi("saksnummer")
-        return if (saksnummer != null) {
-            pep.oppdater(saksnummer)
+        return if (oppgaveIdOgAktører.saksnummer != null) {
+            pep.oppdater(oppgaveIdOgAktører.saksnummer)
         } else {
-            val aktører = hentAktører(oppgave)
-            pep.oppdater(aktører)
+            pep.oppdater(oppgaveIdOgAktører.aktører)
         }
     }
 
@@ -84,31 +109,33 @@ class PepCacheService(
         val diskresjonskoder = pepClient.diskresjonskoderForSak(saksnummer)
 
         //TODO ikke sette kode7 og egenansatt til samme verdi, det er misvisende ifht modellen som finnes. Det fungerer funksjonelt p.t fordi kode7 og egen ansatt (skjermet) håndteres samlet i køene
-        val kode7ellerEgenAnsatt = diskresjonskoder.contains(Diskresjonskode.KODE7) || diskresjonskoder.contains(Diskresjonskode.SKJERMET)
+        val kode7ellerEgenAnsatt =
+            diskresjonskoder.contains(Diskresjonskode.KODE7) || diskresjonskoder.contains(Diskresjonskode.SKJERMET)
         return oppdater(
-                kode6 = diskresjonskoder.contains(Diskresjonskode.KODE6),
-                kode7 = kode7ellerEgenAnsatt,
-                egenAnsatt = kode7ellerEgenAnsatt,
+            kode6 = diskresjonskoder.contains(Diskresjonskode.KODE6),
+            kode7 = kode7ellerEgenAnsatt,
+            egenAnsatt = kode7ellerEgenAnsatt,
         )
     }
 
-    private suspend fun PepCache.oppdater(aktører: List<AktørId>): PepCache {
-        if (aktører.isEmpty()){
+    private suspend fun PepCache.oppdater(aktører: List<String>): PepCache {
+        if (aktører.isEmpty()) {
             return oppdater(kode6 = false, kode7 = false, egenAnsatt = false)
         }
         return coroutineScope {
             val requests = aktører.map {
                 async(Span.current().asContextElement()) {
-                    pepClient.diskresjonskoderForPerson(it.aktørId)
+                    pepClient.diskresjonskoderForPerson(it)
                 }
             }
 
             val diskresjonskoder = requests
-                .map { it.await() }
-                .reduce { a, b -> a + b }
+                .awaitAll()
+                .flatten()
 
             //TODO ikke sette kode7 og egenansatt til samme verdi, det er misvisende ifht modellen som finnes. Det fungerer funksjonelt p.t fordi kode7 og egen ansatt (skjermet) håndteres samlet i køene
-            val kode7ellerEgenAnsatt = diskresjonskoder.contains(Diskresjonskode.KODE7) || diskresjonskoder.contains(Diskresjonskode.SKJERMET)
+            val kode7ellerEgenAnsatt =
+                diskresjonskoder.contains(Diskresjonskode.KODE7) || diskresjonskoder.contains(Diskresjonskode.SKJERMET)
             oppdater(
                 kode6 = diskresjonskoder.contains(Diskresjonskode.KODE6),
                 kode7 = kode7ellerEgenAnsatt,
@@ -116,16 +143,10 @@ class PepCacheService(
             )
         }
     }
-
-    private fun hentAktører(oppgave: Oppgave): List<AktørId> {
-        return listOfNotNull(
-            oppgave.hentVerdi("aktorId"),
-            oppgave.hentVerdi("pleietrengendeAktorId"),
-            oppgave.hentVerdi("relatertPartAktorid")
-        ).map { AktørId(it) }
-    }
-
-    private data class AktørId(val aktørId: String)
-
 }
 
+data class PepCacheInput(
+    val eksternId: String,
+    val saksnummer: String?,
+    val aktører: List<String>
+)

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/infrastruktur/abac/cache/PepCacheService.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/infrastruktur/abac/cache/PepCacheService.kt
@@ -5,10 +5,8 @@ import io.opentelemetry.extension.kotlin.asContextElement
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import kotlinx.coroutines.*
 import kotliquery.TransactionalSession
-import kotliquery.queryOf
 import no.nav.k9.los.nyoppgavestyring.infrastruktur.abac.IPepClient
 import no.nav.k9.los.nyoppgavestyring.infrastruktur.db.TransactionalManager
-import no.nav.k9.los.nyoppgavestyring.infrastruktur.db.util.InClauseHjelper
 import no.nav.k9.los.nyoppgavestyring.mottak.oppgave.Oppgavestatus
 import no.nav.sif.abac.kontrakt.abac.Diskresjonskode
 import java.time.Duration
@@ -31,7 +29,7 @@ class PepCacheService(
     ) {
         transactionalManager.transaction { tx ->
             runBlocking(Dispatchers.IO) {
-                val oppgaverSomMåOppdateres = hentOppgaverMedStatusOgPepCacheEldreEnn(
+                val oppgaverSomMåOppdateres = pepCacheRepository.hentOppgaverMedStatusOgPepCacheEldreEnn(
                     tidspunkt = LocalDateTime.now() - gyldighet,
                     antall = 1,
                     status = status,
@@ -40,48 +38,6 @@ class PepCacheService(
                 oppgaverSomMåOppdateres.forEach { oppgave -> oppdater(tx, oppgave) }
             }
         }
-    }
-
-    private fun hentOppgaverMedStatusOgPepCacheEldreEnn(
-        tidspunkt: LocalDateTime = LocalDateTime.now(),
-        antall: Int = 1,
-        status: Set<Oppgavestatus>,
-        tx: TransactionalSession
-    ): List<PepCacheInput> {
-        val statusParametre = InClauseHjelper.tilParameternavn(status, "status")
-        val query = """
-                    SELECT o.oppgave_ekstern_id, 
-                    (select ov.verdi from oppgavefelt_verdi_part ov where ov.oppgave_id = o.id AND ov.feltdefinisjon_ekstern_id = 'saksnummer' AND ov.oppgavestatus IN ($statusParametre)) as saksnummer,
-                    (select ov.verdi from oppgavefelt_verdi_part ov where ov.oppgave_id = o.id AND ov.feltdefinisjon_ekstern_id = 'aktorId' AND ov.oppgavestatus IN ($statusParametre)) as aktor_id,
-                    (select ov.verdi from oppgavefelt_verdi_part ov where ov.oppgave_id = o.id AND ov.feltdefinisjon_ekstern_id = 'pleietrengendeAktorId' AND ov.oppgavestatus IN ($statusParametre)) as pleietrengende_aktor_id,
-                    (select ov.verdi from oppgavefelt_verdi_part ov where ov.oppgave_id = o.id AND ov.feltdefinisjon_ekstern_id = 'relatertPartAktorid' AND ov.oppgavestatus IN ($statusParametre)) as relatert_part_aktor_id
-                    FROM oppgave_v3_part o 
-                    LEFT JOIN OPPGAVE_PEP_CACHE opc ON o.oppgave_ekstern_id = opc.ekstern_id
-                    WHERE o.oppgavestatus IN ($statusParametre)
-                    AND (opc.oppdatert is null OR opc.oppdatert < :grense)
-                    ORDER BY opc.oppdatert NULLS FIRST
-                    LIMIT :limit
-                """.trimIndent()
-        return tx.run(
-            queryOf(
-                query,
-                buildMap {
-                    put("grense", tidspunkt)
-                    put("limit", antall)
-                    putAll(InClauseHjelper.parameternavnTilVerdierMap(status.map { it.kode }, "status"))
-                }
-            ).map { row ->
-                PepCacheInput(
-                    row.string("oppgave_ekstern_id"),
-                    row.stringOrNull("saksnummer"),
-                    listOfNotNull(
-                        row.stringOrNull("aktor_id"),
-                        row.stringOrNull("pleietrengende_aktor_id"),
-                        row.stringOrNull("relatert_part_aktor_id")
-                    )
-                )
-            }.asList
-        )
     }
 
     suspend fun oppdater(tx: TransactionalSession, oppgave: PepCacheInput): PepCache {

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/infrastruktur/db/util/InClauseHjelper.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/infrastruktur/db/util/InClauseHjelper.kt
@@ -1,7 +1,6 @@
 package no.nav.k9.los.nyoppgavestyring.infrastruktur.db.util
 
 object InClauseHjelper {
-
     fun <T> tilParameternavnMedCast(input: Collection<T>, prefix: String, castTilType: String): String {
         return tilParameternavnListe(input, "cast(:$prefix", " as $castTilType)").joinToString(",")
     }
@@ -17,6 +16,5 @@ object InClauseHjelper {
     private fun <T> tilParameternavnListe(input: Collection<T>, prefix: String, postfix: String = ""): List<String> {
         check(input.isNotEmpty())
         return IntRange(1, input.size).map { "$prefix$it$postfix" }
-
     }
 }

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/visningoguttrekk/OppgaveRepository.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/visningoguttrekk/OppgaveRepository.kt
@@ -4,9 +4,8 @@ import kotliquery.Row
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
 import no.nav.k9.los.nyoppgavestyring.infrastruktur.db.util.InClauseHjelper
-import no.nav.k9.los.nyoppgavestyring.query.db.OppgaveV3Id
-import no.nav.k9.los.nyoppgavestyring.mottak.oppgave.Oppgavestatus
 import no.nav.k9.los.nyoppgavestyring.mottak.oppgavetype.OppgavetypeRepository
+import no.nav.k9.los.nyoppgavestyring.query.db.OppgaveV3Id
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
@@ -147,34 +146,6 @@ class OppgaveRepository(
                     verdiBigInt = row.longOrNull("verdi_bigint"),
                 )
             }.asList
-        )
-    }
-
-    fun hentOppgaverMedStatusOgPepCacheEldreEnn(
-        tidspunkt: LocalDateTime = LocalDateTime.now(),
-        antall: Int = 1,
-        status: Set<Oppgavestatus>,
-        tx: TransactionalSession
-    ): List<Oppgave> {
-        val query = """
-                    SELECT o.*
-                    FROM oppgave_v3 o 
-                    LEFT JOIN OPPGAVE_PEP_CACHE opc ON (
-                        o.kildeomrade = opc.kildeomrade AND o.ekstern_id = opc.ekstern_id
-                    )
-                    WHERE o.aktiv is true AND o.status IN ('${status.joinToString("','")}')
-                    AND (opc.oppdatert is null OR opc.oppdatert < :grense)
-                    ORDER BY opc.oppdatert NULLS FIRST
-                    LIMIT :limit
-                """.trimIndent()
-        return tx.run(
-            queryOf(
-                query,
-                mapOf(
-                    "grense" to tidspunkt,
-                    "limit" to antall
-                )
-            ).map { row -> mapOppgave(row, tidspunkt, tx) }.asList
         )
     }
 }

--- a/src/test/kotlin/no/nav/k9/los/KoinModules.kt
+++ b/src/test/kotlin/no/nav/k9/los/KoinModules.kt
@@ -108,7 +108,6 @@ fun buildAndTestConfig(dataSource: DataSource, pepClient: IPepClient = PepClient
         PepCacheService(
             pepClient = get(),
             pepCacheRepository = get(),
-            oppgaveRepository = get(),
             transactionalManager = get()
         )
     }

--- a/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/infrastruktur/abac/cache/PepCacheServiceTest.kt
+++ b/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/infrastruktur/abac/cache/PepCacheServiceTest.kt
@@ -4,10 +4,7 @@ import assertk.assertThat
 import assertk.assertions.*
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import io.mockk.coEvery
-import io.mockk.mockk
-import io.mockk.slot
-import io.mockk.verify
+import io.mockk.*
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -220,7 +217,7 @@ class PepCacheServiceTest : KoinTest, AbstractPostgresTest() {
     @Test
     fun `oppdaterCacheForOppgaverEldreEnn skal oppdatere alle oppgaver eldre enn oppgitt alder`() {
         val k9sakEventHandler = get<K9SakEventHandler>()
-        val pepRepository = mockk<PepCacheRepository>(relaxed = true)
+        val pepRepository = spyk(get<PepCacheRepository>())
 
         val saksnummer = "TEST3"
         gjørSakOrdinær(saksnummer)

--- a/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/infrastruktur/abac/cache/PepCacheServiceTest.kt
+++ b/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/infrastruktur/abac/cache/PepCacheServiceTest.kt
@@ -228,7 +228,6 @@ class PepCacheServiceTest : KoinTest, AbstractPostgresTest() {
         val pepCacheService = PepCacheService(
             pepCacheRepository = pepRepository,
             pepClient = pepClient,
-            oppgaveRepository = get(),
             transactionalManager = get()
         )
 
@@ -258,7 +257,6 @@ class PepCacheServiceTest : KoinTest, AbstractPostgresTest() {
         val pepCacheService = PepCacheService(
             pepCacheRepository = pepRepository,
             pepClient = pepClient,
-            oppgaveRepository = get(),
             transactionalManager = get()
         )
 


### PR DESCRIPTION
### Behov / Bakgrunn
Mer effektiv spørring. Ha færre avhengigheter til oppgave_v3.

### Løsning
Implementerer databasespørring i PepCacheRepository siden spørringen er spesialisert med joins til både pepcache og oppgave-tabeller. Siden det uansett er en spesialisert spørring hentes bare de feltene som behøves i pep-kallet (saksnummer og de tre mulige aktør-idene).

### Andre endringer

