### PR TITLE
Forbedre ytelse på /avdelingsleder/saksbehandlere ved å begrense antallet spørringer

### DIFF
--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/reservasjon/ReservasjonV3Repository.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/reservasjon/ReservasjonV3Repository.kt
@@ -3,6 +3,7 @@ package no.nav.k9.los.nyoppgavestyring.reservasjon
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
 import no.nav.k9.los.nyoppgavestyring.infrastruktur.db.TransactionalManager
+import no.nav.k9.los.nyoppgavestyring.infrastruktur.db.util.InClauseHjelper
 import org.postgresql.util.PSQLException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -192,21 +193,23 @@ class ReservasjonV3Repository(
         saksbehandlerId: Set<Long>,
         tx: TransactionalSession
     ): Map<Long, Int> {
-        val ufiltrert = tx.run(
+        val saksbehandlerIdParametre = InClauseHjelper.tilParameternavn(saksbehandlerId, "saksbehandlerId")
+        val resultat = tx.run(
             queryOf(
                 """
                    select reservertAv, count(*) as antall
                    from reservasjon_v3 r
-                   where r.reservertAv = :reservertAv
+                   where r.reservertAv in ($saksbehandlerIdParametre)
                        and annullert_for_utlop = false
                        and lower(r.gyldig_tidsrom) <= :now
                        and upper(r.gyldig_tidsrom) > :now
                    group by reservertAv
                     """.trimIndent(),
-                mapOf(
-                    "reservertAv" to saksbehandlerId,
-                    "now" to LocalDateTime.now().truncatedTo(ChronoUnit.MICROS),
-                )
+                buildMap {
+                    put("reservertAv", saksbehandlerId)
+                    put("now" ,LocalDateTime.now().truncatedTo(ChronoUnit.MICROS))
+                    putAll(InClauseHjelper.parameternavnTilVerdierMap(saksbehandlerId, "saksbehandlerId"))
+                }
             ).map { row ->
                 AntallReservasjonerForSaksbehandler(
                     saksbehandlerId = row.long("reservertAv"),
@@ -216,7 +219,7 @@ class ReservasjonV3Repository(
                 .asList
 
         )
-        return ufiltrert.filter { saksbehandlerId.contains(it.saksbehandlerId) }
+        return resultat
             .map { it.saksbehandlerId to it.antallReservasjoner }
             .toMap()
     }

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/reservasjon/ReservasjonV3Repository.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/reservasjon/ReservasjonV3Repository.kt
@@ -8,7 +8,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
-import java.util.UUID
+import java.util.*
 
 class ReservasjonV3Repository(
     private val transactionalManager: TransactionalManager,
@@ -188,29 +188,43 @@ class ReservasjonV3Repository(
         )
     }
 
-    fun tellAktiveReservasjonerForSaksbehandler(
-        saksbehandlerId: Long,
+    fun tellAktiveReservasjonerForSaksbehandlere(
+        saksbehandlerId: Set<Long>,
         tx: TransactionalSession
-    ): Int {
-        return tx.run(
+    ): Map<Long, Int> {
+        val ufiltrert = tx.run(
             queryOf(
                 """
-                   select count(*)
+                   select reservertAv, count(*) as antall
                    from reservasjon_v3 r
                    where r.reservertAv = :reservertAv
                        and annullert_for_utlop = false
                        and lower(r.gyldig_tidsrom) <= :now
                        and upper(r.gyldig_tidsrom) > :now
+                   group by reservertAv
                     """.trimIndent(),
                 mapOf(
                     "reservertAv" to saksbehandlerId,
                     "now" to LocalDateTime.now().truncatedTo(ChronoUnit.MICROS),
                 )
             ).map { row ->
-                row.int(1)
-            }.asSingle
-        ) ?: 0
+                AntallReservasjonerForSaksbehandler(
+                    saksbehandlerId = row.long("reservertAv"),
+                    antallReservasjoner = row.int("antall")
+                )
+            }
+                .asList
+
+        )
+        return ufiltrert.filter { saksbehandlerId.contains(it.saksbehandlerId) }
+            .map { it.saksbehandlerId to it.antallReservasjoner }
+            .toMap()
     }
+
+    data class AntallReservasjonerForSaksbehandler(
+        val saksbehandlerId: Long,
+        val antallReservasjoner: Int
+    )
 
     fun hentAktiveReservasjonerForSaksbehandler(
         saksbehandlerId: Long,

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/reservasjon/ReservasjonV3Tjeneste.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/reservasjon/ReservasjonV3Tjeneste.kt
@@ -152,8 +152,8 @@ class ReservasjonV3Tjeneste(
         return reservasjonV3Repository.hentAktivReservasjonForReservasjonsnøkkel(reservasjonsnøkkel, tx)
     }
 
-    fun tellReservasjonerForSaksbehandler(saksbehandlerId: Long, tx: TransactionalSession): Int {
-        return reservasjonV3Repository.tellAktiveReservasjonerForSaksbehandler(saksbehandlerId, tx)
+    fun tellReservasjonerForSaksbehandlere(saksbehandlerIder: Set<Long>, tx: TransactionalSession): Map<Long, Int> {
+        return reservasjonV3Repository.tellAktiveReservasjonerForSaksbehandlere(saksbehandlerIder, tx)
     }
 
     fun hentReservasjonerForSaksbehandler(saksbehandlerId: Long): List<ReservasjonV3MedOppgaver> {

--- a/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/saksbehandleradmin/SaksbehandlerAdminTjeneste.kt
+++ b/src/main/kotlin/no/nav/k9/los/nyoppgavestyring/saksbehandleradmin/SaksbehandlerAdminTjeneste.kt
@@ -94,6 +94,9 @@ class SaksbehandlerAdminTjeneste(
     suspend fun hentSaksbehandlere(): List<SaksbehandlerDto> {
         return transactionalManager.transactionSuspend { tx ->
             val saksbehandlere = saksbehandlerRepository.hentAlleSaksbehandlere(tx)
+            val saksbehandlerIder = saksbehandlere.map { it.id!! }.toSet()
+            val antallReservasjoner = reservasjonV3Tjeneste.tellReservasjonerForSaksbehandlere(saksbehandlerIder, tx)
+
             saksbehandlere.map {
                 SaksbehandlerDto(
                     id = it.id,
@@ -101,7 +104,7 @@ class SaksbehandlerAdminTjeneste(
                     navn = it.navn,
                     epost = it.epost,
                     enhet = it.enhet,
-                    antallAktiveReservasjoner = reservasjonV3Tjeneste.tellReservasjonerForSaksbehandler(it.id!!, tx)
+                    antallAktiveReservasjoner = antallReservasjoner.getOrElse(it.id!!) { 0 }
                 )
             }.sortedBy { it.navn }
         }

--- a/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/reservasjon/ReservasjonV3RepositoryTest.kt
+++ b/src/test/kotlin/no/nav/k9/los/nyoppgavestyring/reservasjon/ReservasjonV3RepositoryTest.kt
@@ -364,4 +364,102 @@ class ReservasjonV3RepositoryTest : AbstractK9LosIntegrationTest() {
         assertThat(forlengetReservasjon.gyldigTil).isEqualTo(reservasjon.gyldigTil.plusDays(1))
         assertThat(forlengetReservasjon.kommentar).isEqualTo("testkommentar")
     }
+
+    @Test
+    fun `Skal hente riktig antall reservasjoner for saksbehandlerne, og for kun de saksbehandlerne som er i lista`() {
+        val saksbehandlerRepository = get<SaksbehandlerRepository>()
+        val reservasjonV3Repository = get<ReservasjonV3Repository>()
+        val transactionalManager = get<TransactionalManager>()
+
+        val saksbehandler1 = runBlocking {
+            saksbehandlerRepository.addSaksbehandler(
+                Saksbehandler(
+                    id = null,
+                    navident = null,
+                    navn = null,
+                    epost = "test1@test.no",
+                    enhet = null,
+                )
+            )
+            saksbehandlerRepository.finnSaksbehandlerMedEpost("test1@test.no")!!
+        }
+        val saksbehandler2 = runBlocking {
+            saksbehandlerRepository.addSaksbehandler(
+                Saksbehandler(
+                    id = null,
+                    navident = null,
+                    navn = null,
+                    epost = "test2@test.no",
+                    enhet = null,
+                )
+            )
+            saksbehandlerRepository.finnSaksbehandlerMedEpost("test2@test.no")!!
+        }
+        val saksbehandler3skjermet = runBlocking {
+            saksbehandlerRepository.addSaksbehandler(
+                Saksbehandler(
+                    id = null,
+                    navident = null,
+                    navn = null,
+                    epost = "test3@test.no",
+                    enhet = null,
+                )
+            )
+            saksbehandlerRepository.finnSaksbehandlerMedEpost("test3@test.no")!!
+        }
+
+        val reservasjon1 = ReservasjonV3(
+            reservertAv = saksbehandler1.id!!,
+            reservasjonsnøkkel = "test1",
+            gyldigFra = LocalDateTime.now(),
+            gyldigTil = LocalDateTime.now().plusDays(1),
+            kommentar = "",
+            endretAv = null
+        )
+        val reservasjon2 = ReservasjonV3(
+            reservertAv = saksbehandler1.id!!,
+            reservasjonsnøkkel = "test2",
+            gyldigFra = LocalDateTime.now(),
+            gyldigTil = LocalDateTime.now().plusDays(1),
+            kommentar = "",
+            endretAv = null
+        )
+        val reservasjon3 = ReservasjonV3(
+            reservertAv = saksbehandler2.id!!,
+            reservasjonsnøkkel = "test3",
+            gyldigFra = LocalDateTime.now(),
+            gyldigTil = LocalDateTime.now().plusDays(1),
+            kommentar = "",
+            endretAv = null
+        )
+        val reservasjon4 = ReservasjonV3(
+            reservertAv = saksbehandler3skjermet.id!!,
+            reservasjonsnøkkel = "test4",
+            gyldigFra = LocalDateTime.now(),
+            gyldigTil = LocalDateTime.now().plusDays(1),
+            kommentar = "",
+            endretAv = null
+        )
+
+        transactionalManager.transaction { tx ->
+            reservasjonV3Repository.lagreReservasjon(reservasjon1,tx)
+            reservasjonV3Repository.lagreReservasjon(reservasjon2,tx)
+            reservasjonV3Repository.lagreReservasjon(reservasjon3,tx)
+            reservasjonV3Repository.lagreReservasjon(reservasjon4,tx)
+        }
+
+        val resultat = transactionalManager.transaction { tx ->
+            reservasjonV3Repository.tellAktiveReservasjonerForSaksbehandlere(
+                setOf(
+                    saksbehandler1.id!!,
+                    saksbehandler2.id!!
+                ), tx
+            )
+        }
+
+        assertEquals(resultat, mapOf(
+            saksbehandler1.id!! to 2,
+            saksbehandler2.id!! to 1
+        ))
+    }
 }


### PR DESCRIPTION
### Behov / Bakgrunn
Dette endepunktet bruker over 2 sekunder på å gi svar, fordi det gjøres mange kall til databasen for å hente antall reservasjoner

### Løsning
Bruk group by for å hente alle tallene på en gang

### Andre endringer

