### PR TITLE
Viser de nye aksjonspunktfeltene under streken

### DIFF
--- a/src/main/resources/adapterdefinisjoner/k9-feltdefinisjoner-v2.json
+++ b/src/main/resources/adapterdefinisjoner/k9-feltdefinisjoner-v2.json
@@ -233,7 +233,7 @@
       "beskrivelse": "Aksjonspunkter som er utført",
       "listetype": true,
       "tolkesSom": "String",
-      "synlighet": "SKJULT",
+      "synlighet": "UNDER_STREKEN",
       "kodeverkreferanse": {
         "område": "K9",
         "eksternId": "Aksjonspunkt"
@@ -245,7 +245,7 @@
       "beskrivelse": "Aksjonspunkter som er avbrutt",
       "listetype": true,
       "tolkesSom": "String",
-      "synlighet": "SKJULT",
+      "synlighet": "UNDER_STREKEN",
       "kodeverkreferanse": {
         "område": "K9",
         "eksternId": "Aksjonspunkt"
@@ -257,7 +257,7 @@
       "beskrivelse": "Åpne aksjonspunkter som ikke kan løses i steget behandlingen står i nå",
       "listetype": true,
       "tolkesSom": "String",
-      "synlighet": "SKJULT",
+      "synlighet": "UNDER_STREKEN",
       "kodeverkreferanse": {
         "område": "K9",
         "eksternId": "Aksjonspunkt"


### PR DESCRIPTION
Viser både nye og gamle felter. Etter at køer/søk er migrert kan de gamle fjernes.