### PR TITLE
Reservasjonsnøkkel som input til handlinger på reservasjon

### DIFF
--- a/src/main/kotlin/no/nav/k9/los/reservasjon/AnnullerReservasjon.kt
+++ b/src/main/kotlin/no/nav/k9/los/reservasjon/AnnullerReservasjon.kt
@@ -1,7 +1,0 @@
-package no.nav.k9.los.reservasjon
-
-import no.nav.k9.los.oppgaveuthenting.OppgaveNøkkelDto
-
-data class AnnullerReservasjon(
-    val oppgaveNøkkel: OppgaveNøkkelDto,
- )

--- a/src/main/kotlin/no/nav/k9/los/reservasjon/AnnullerReservasjonDto.kt
+++ b/src/main/kotlin/no/nav/k9/los/reservasjon/AnnullerReservasjonDto.kt
@@ -1,0 +1,8 @@
+package no.nav.k9.los.reservasjon
+
+import no.nav.k9.los.oppgaveuthenting.OppgaveNøkkelDto
+
+data class AnnullerReservasjonDto(
+    val oppgaveNøkkel: OppgaveNøkkelDto?,
+    val reservasjonsnøkkel: String?
+ )

--- a/src/main/kotlin/no/nav/k9/los/reservasjon/FlyttReservasjonDto.kt
+++ b/src/main/kotlin/no/nav/k9/los/reservasjon/FlyttReservasjonDto.kt
@@ -1,11 +1,10 @@
 package no.nav.k9.los.reservasjon
 
 import no.nav.k9.los.oppgaveuthenting.OppgaveNøkkelDto
-import java.time.LocalDateTime
 
-data class ForlengReservasjonDto(
+data class FlyttReservasjonDto(
     val oppgaveNøkkel: OppgaveNøkkelDto?,
     val reservasjonsnøkkel: String?,
-    val kommentar: String?,
-    val nyTilDato: LocalDateTime?,
+    val brukerIdent: String,
+    val begrunnelse: String
 )

--- a/src/main/kotlin/no/nav/k9/los/reservasjon/FlyttReservasjonId.kt
+++ b/src/main/kotlin/no/nav/k9/los/reservasjon/FlyttReservasjonId.kt
@@ -1,8 +1,0 @@
-package no.nav.k9.los.reservasjon
-
-import no.nav.k9.los.oppgaveuthenting.OppgaveNøkkelDto
-
-data class FlyttReservasjonId(
-    val oppgaveNøkkel: OppgaveNøkkelDto,
-    val brukerIdent: String,
-    val begrunnelse: String)

--- a/src/main/kotlin/no/nav/k9/los/reservasjon/ReservasjonApis.kt
+++ b/src/main/kotlin/no/nav/k9/los/reservasjon/ReservasjonApis.kt
@@ -71,7 +71,7 @@ internal fun Route.ReservasjonApis() {
     post("/opphev") {
         requestContextService.withRequestContext(call) {
             if (pepClient.harBasisTilgang()) {
-                val params = call.receive<List<AnnullerReservasjon>>()
+                val params = call.receive<List<AnnullerReservasjonDto>>()
                 val innloggetBruker = saksbehandlerRepository.finnSaksbehandlerMedIdent(kotlin.coroutines.coroutineContext.idToken().getNavIdent())!!
 
                 try {
@@ -113,14 +113,14 @@ internal fun Route.ReservasjonApis() {
     post("/flytt") {
         requestContextService.withRequestContext(call) {
             if (pepClient.harBasisTilgang()) {
-                val params = call.receive<FlyttReservasjonId>()
+                val params = call.receive<FlyttReservasjonDto>()
 
                 val innloggetBruker = saksbehandlerRepository.finnSaksbehandlerMedIdent(
                     kotlin.coroutines.coroutineContext.idToken().getNavIdent()
                 )!!
 
                 try {
-                    log.info("Flytter reservasjonen ${params.oppgaveNøkkel.oppgaveEksternId} til ${params.brukerIdent} (Gjort av ${innloggetBruker.navident})")
+                    log.info("Flytter reservasjonen til ${params.brukerIdent} (Gjort av ${innloggetBruker.navident})")
                     call.respond(reservasjonApisTjeneste.overførReservasjon(params, innloggetBruker))
                 } catch (e: FinnerIkkeDataException) {
                     call.respond(HttpStatusCode.NotFound, "Fant ingen aktiv reservasjon for angitt reservasjonsnøkkel")

--- a/src/main/kotlin/no/nav/k9/los/reservasjon/ReservasjonApisTjeneste.kt
+++ b/src/main/kotlin/no/nav/k9/los/reservasjon/ReservasjonApisTjeneste.kt
@@ -71,7 +71,7 @@ class ReservasjonApisTjeneste(
         reservasjonEndringDto.forEach {
             endreReservasjon(
                 innloggetBruker,
-                it.oppgaveNøkkel,
+                it,
                 it.brukerIdent,
                 it.reserverTil,
                 it.begrunnelse
@@ -81,7 +81,7 @@ class ReservasjonApisTjeneste(
 
     private suspend fun endreReservasjon(
         innloggetBruker: Saksbehandler,
-        oppgaveNøkkel: OppgaveNøkkelDto,
+        endringDto: ReservasjonEndringDto,
         tilBrukerIdent: String? = null,
         reserverTil: LocalDate? = null,
         begrunnelse: String? = null
@@ -89,9 +89,9 @@ class ReservasjonApisTjeneste(
         val tilSaksbehandler =
             tilBrukerIdent?.let { saksbehandlerRepository.finnSaksbehandlerMedIdent(it) }
 
-        val reservasjonsnøkkel = aktivOppgaveOppslag.hentAktivOppgave(
-            oppgaveNøkkel.oppgaveEksternId,
-            oppgaveNøkkel.oppgaveTypeEksternId
+        val reservasjonsnøkkel = endringDto.reservasjonsnøkkel ?: aktivOppgaveOppslag.hentAktivOppgave(
+            endringDto.oppgaveNøkkel!!.oppgaveEksternId,
+            endringDto.oppgaveNøkkel.oppgaveTypeEksternId
         ).reservasjonsnøkkel
         val nyReservasjon = reservasjonV3Tjeneste.endreReservasjon(
             reservasjonsnøkkel = reservasjonsnøkkel,
@@ -107,7 +107,7 @@ class ReservasjonApisTjeneste(
         )
 
         val reservertAv = saksbehandlerRepository.finnSaksbehandlerMedId(nyReservasjon.reservasjonV3.reservertAv)!!
-        log.info("endreReservasjon: ${oppgaveNøkkel.oppgaveEksternId}, ${nyReservasjon.reservasjonV3}, reservertAv: $reservertAv")
+        log.info("endreReservasjon: ${nyReservasjon.reservasjonV3}, reservertAv: $reservertAv")
 
         return reservasjonV3DtoBuilder.byggReservasjonV3Dto(nyReservasjon, reservertAv)
     }
@@ -117,8 +117,8 @@ class ReservasjonApisTjeneste(
         innloggetBruker: Saksbehandler
     ): ReservasjonV3Dto {
         val reservasjonsnøkkel =
-            aktivOppgaveOppslag.hentAktivOppgave(
-                forlengReservasjonDto.oppgaveNøkkel.oppgaveEksternId,
+            forlengReservasjonDto.reservasjonsnøkkel ?: aktivOppgaveOppslag.hentAktivOppgave(
+                forlengReservasjonDto.oppgaveNøkkel!!.oppgaveEksternId,
                 forlengReservasjonDto.oppgaveNøkkel.oppgaveTypeEksternId
             ).reservasjonsnøkkel
 
@@ -132,21 +132,21 @@ class ReservasjonApisTjeneste(
 
         val reservertAv =
             saksbehandlerRepository.finnSaksbehandlerMedId(forlengetReservasjon.reservasjonV3.reservertAv)!!
-        log.info("forlengReservasjon: ${forlengReservasjonDto.oppgaveNøkkel.oppgaveEksternId}, ${forlengetReservasjon.reservasjonV3}, reservertAv: $reservertAv")
+        log.info("forlengReservasjon: ${forlengetReservasjon.reservasjonV3}, reservertAv: $reservertAv")
 
         return reservasjonV3DtoBuilder.byggReservasjonV3Dto(forlengetReservasjon, reservertAv)
     }
 
     suspend fun overførReservasjon(
-        params: FlyttReservasjonId,
+        params: FlyttReservasjonDto,
         innloggetBruker: Saksbehandler
     ): ReservasjonV3Dto {
         val tilSaksbehandler = saksbehandlerRepository.finnSaksbehandlerMedIdent(
             params.brukerIdent
         )!!
 
-        val reservasjonsnøkkel = aktivOppgaveOppslag.hentAktivOppgave(
-            params.oppgaveNøkkel.oppgaveEksternId,
+        val reservasjonsnøkkel = params.reservasjonsnøkkel ?: aktivOppgaveOppslag.hentAktivOppgave(
+            params.oppgaveNøkkel!!.oppgaveEksternId,
             params.oppgaveNøkkel.oppgaveTypeEksternId
         ).reservasjonsnøkkel
 
@@ -157,18 +157,18 @@ class ReservasjonApisTjeneste(
             utførtAvBrukerId = innloggetBruker.id!!,
             kommentar = params.begrunnelse,
         )
-        log.info("overførReservasjon: ${params.oppgaveNøkkel.oppgaveEksternId}, ${nyReservasjon.reservasjonV3}, utførtAv: $innloggetBruker., tilSaksbehandler: $tilSaksbehandler")
+        log.info("overførReservasjon: ${nyReservasjon.reservasjonV3}, utførtAv: $innloggetBruker., tilSaksbehandler: $tilSaksbehandler")
 
         return reservasjonV3DtoBuilder.byggReservasjonV3Dto(nyReservasjon, tilSaksbehandler)
     }
 
     private fun annullerReservasjon(
         innloggetBruker: Saksbehandler,
-        oppgaveNøkkelDto: OppgaveNøkkelDto,
+        annullerReservasjon: AnnullerReservasjonDto,
     ) {
-        val reservasjonsnøkkel = aktivOppgaveOppslag.hentAktivOppgave(
-            oppgaveNøkkelDto.oppgaveEksternId,
-            oppgaveNøkkelDto.oppgaveTypeEksternId
+        val reservasjonsnøkkel = annullerReservasjon.reservasjonsnøkkel ?: aktivOppgaveOppslag.hentAktivOppgave(
+            annullerReservasjon.oppgaveNøkkel!!.oppgaveEksternId,
+            annullerReservasjon.oppgaveNøkkel.oppgaveTypeEksternId
         ).reservasjonsnøkkel
 
         val annulleringUtført = reservasjonV3Tjeneste.annullerReservasjonHvisFinnes(
@@ -176,17 +176,17 @@ class ReservasjonApisTjeneste(
             null,
             annullertAvBrukerId = innloggetBruker.id!!
         )
-        log.info("annullerReservasjon: ${oppgaveNøkkelDto.oppgaveEksternId}, utførtAv: $innloggetBruker, $annulleringUtført")
+        log.info("annullerReservasjon, utførtAv: $innloggetBruker, $annulleringUtført")
     }
 
     fun annullerReservasjoner(
-        params: List<AnnullerReservasjon>,
+        params: List<AnnullerReservasjonDto>,
         innloggetBruker: Saksbehandler
     ) {
         params.forEach {
             annullerReservasjon(
                 innloggetBruker,
-                it.oppgaveNøkkel,
+                it,
             )
         }
     }

--- a/src/main/kotlin/no/nav/k9/los/reservasjon/ReservasjonEndringDto.kt
+++ b/src/main/kotlin/no/nav/k9/los/reservasjon/ReservasjonEndringDto.kt
@@ -4,7 +4,8 @@ import no.nav.k9.los.oppgaveuthenting.OppgaveNøkkelDto
 import java.time.LocalDate
 
 data class ReservasjonEndringDto (
-    val oppgaveNøkkel: OppgaveNøkkelDto,
+    val oppgaveNøkkel: OppgaveNøkkelDto?,
+    val reservasjonsnøkkel: String?,
     val brukerIdent: String? = null,
     val reserverTil: LocalDate? = null,
     val begrunnelse: String? = null


### PR DESCRIPTION
Innfører reservasjonsnøkkel som valgfri parameter på reservasjonshandlinger og gjør oppgavenøkkel valgfri der den tidligere var påkrevd. Frontend kan nå gå over til å bruke reservasjonsnøkkel.

Logger ikke reservasjonsnøkkel, siden den inneholder aktør-id, der det før ble logget oppgavenøkkel.