### PR TITLE
Opprydning byggfeil pga manglende enumverdi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <koin.version>4.2.2</koin.version>
         <kotest.version>6.1.11</kotest.version>
         <kotliquery.version>1.9.1</kotliquery.version>
-        <k9-sak.version>7.2.0</k9-sak.version>
+        <k9-sak.version>7.3.1</k9-sak.version>
         <k9-klage.version>0.5.2</k9-klage.version>
         <jackson.version>2.21.3</jackson.version>
         <commons-text.version>1.15.0</commons-text.version>

--- a/src/main/kotlin/no/nav/k9/los/domeneadaptere/k9/OmrådeSetup.kt
+++ b/src/main/kotlin/no/nav/k9/los/domeneadaptere/k9/OmrådeSetup.kt
@@ -185,6 +185,7 @@ class OmrådeSetup(
             BehandlingStegType.FORESLÅ_BEHANDLINGSRESULTAT,
             BehandlingStegType.FORTSETT_FORESLÅ_BEREGNINGSGRUNNLAG,
             BehandlingStegType.VURDER_TILKOMMET_INNTEKT,
+            BehandlingStegType.FASTSETT_INNTEKTSGRADERING,
             BehandlingStegType.FASTSETT_BEREGNINGSGRUNNLAG -> Triple("Beregning", Synlighet.OVER_STREKEN, 4)
 
             BehandlingStegType.SIMULER_OPPDRAG,


### PR DESCRIPTION
### Behov / Bakgrunn
Github actions build finner tak i ny enum-verdi av en eller annen grunn, og bygget feiler, dette til tross for at k9-sak versjon ikke var oppdatert

### Løsning


### Andre endringer

