### PR TITLE
chore: fjern vault serviceuser-path

### DIFF
--- a/nais/naiserator.yml
+++ b/nais/naiserator.yml
@@ -45,8 +45,6 @@ spec:
   vault:
     enabled: true
     paths:
-      - mountPath: /var/run/secrets/nais.io/serviceuser
-        kvPath: {{serviceuser_kvpath}}
       - mountPath: /var/run/secrets/nais.io/vault
         kvPath: {{vault_kvpath}}
   webproxy: true

--- a/src/main/resources/init-scripts/run.sh
+++ b/src/main/resources/init-scripts/run.sh
@@ -1,12 +1,5 @@
 #!/usr/bin/env sh
 set -eu
-echo "Setting SYSTEMBRUKER_USERNAME and SYSTEMBRUKER_PASSWORD"
-if test -f /var/run/secrets/nais.io/serviceuser/username
-then
-    export SYSTEMBRUKER_USERNAME="$(cat /var/run/secrets/nais.io/serviceuser/username)"
-    export SYSTEMBRUKER_PASSWORD="$(cat /var/run/secrets/nais.io/serviceuser/password)"
-fi
-
 
 echo "Importing Azure credentials"
 


### PR DESCRIPTION
### Behov / Bakgrunn

Som del av migrering bort fra service users til client credentials-flyt fjerner vi Vault serviceuser-paths som ikke lenger er i bruk. Vault-agenten injiserte `SYSTEMBRUKER_USERNAME/PASSWORD` i containeren via init-script, men ingen kode leser disse env-variablene.

### Løsning

- Fjerner `serviceuser`-path fra `nais/naiserator.yml`\n- Fjerner serviceuser-blokk fra `src/main/resources/init-scripts/run.sh`

`vault.enabled: true` beholdes der det er nødvendig for HikariCPVaultUtil (DB-credentials via `postgresql/`).

### Andre endringer

Ingen.

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres